### PR TITLE
Add automatic package conversion from Mod Compendium structure

### DIFF
--- a/ConfigObj.cs
+++ b/ConfigObj.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Windows.Documents;
+using System.Xml.Serialization;
 
 namespace AemulusModManager
 {
@@ -29,6 +30,20 @@ namespace AemulusModManager
         public string version { get; set; }
         public string link { get; set; }
         public string description { get; set; }
+    }
+
+    [Serializable, XmlRoot("Mod")]
+    public class ModXmlMetadata
+    {
+        public string Id { get; set; }
+        public string Game { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string Version { get; set; }
+        public string Date { get; set; }
+        public string Author { get; set; }
+        public string Url { get; set; }
+        public string UpdateUrl { get; set; }
     }
 
     public class DisplayedMetadata

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -433,13 +433,13 @@ namespace AemulusModManager
                     dirFiles = dirFiles.Concat(dirFolders).ToList();
                     if (dirFiles.Any(x => Path.GetFileName(x).Equals("Mod.xml")) && dirFiles.Any(x => Path.GetFileName(x).Equals("Data")))
                     {
-                        //If mod folder contains Data folder and mod.xml, import mod compendium mod.xml...s
+                        //If mod folder contains Data folder and mod.xml, import mod compendium mod.xml...
                         string modXml = dirFiles.First(x => Path.GetFileName(x).Equals("Mod.xml"));
                         using (FileStream streamWriter = File.Open(modXml, FileMode.Open))
                         {
                             //Deserialize Mod.xml & Use metadata
                             ModXmlMetadata m = (ModXmlMetadata)xsm.Deserialize(streamWriter);
-                            newMetadata.id = m.Author.ToLower().Trim(' ') + "." + m.Title.ToLower().Trim(' ');
+                            newMetadata.id = m.Author.ToLower().Replace(" ","") + "." + m.Title.ToLower().Replace(" ","");
                             newMetadata.author = m.Author;
                             newMetadata.version = m.Version;
                             newMetadata.link = m.Url;
@@ -452,8 +452,10 @@ namespace AemulusModManager
                         //Delete prebuild.bat if exists
                         if (dirFiles.Any(x => Path.GetFileName(x).Equals("prebuild.bat")))
                             File.Delete(dirFiles.First(x => Path.GetFileName(x).Equals("prebuild.bat")));
+                        //Make sure Data folder is gone
                         if (Directory.Exists(dataDir))
                             Directory.Delete(dataDir, true);
+                        //Goodbye old friend
                         File.Delete(modXml);
                     }
                     else


### PR DESCRIPTION
Mods placed in the Packages folder retain metadata from Mod.xml when Package.xml is created, then Mod.xml/Data folder are deleted (and prebuild.bat if it exists).