### PR TITLE
Add Auto Updating

### DIFF
--- a/AemulusModManager.csproj
+++ b/AemulusModManager.csproj
@@ -154,6 +154,8 @@
     <Compile Include="Utilities\PackageUpdating\PackageUpdater.cs" />
     <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItem.cs" />
     <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemFile.cs" />
+    <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemFileMetadata.cs" />
+    <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemFileTree.cs" />
     <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemUpdate.cs" />
     <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemUpdateChange.cs" />
     <Compile Include="Utilities\PreappfileAppend.cs" />

--- a/AemulusModManager.csproj
+++ b/AemulusModManager.csproj
@@ -112,6 +112,12 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Octokit, Version=0.49.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Octokit.0.49.0\lib\net46\Octokit.dll</HintPath>
+    </Reference>
+    <Reference Include="Onova, Version=2.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Onova.2.6.2\lib\net461\Onova.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Linq" />
@@ -140,8 +146,23 @@
     </ApplicationDefinition>
     <Compile Include="Utilities\BmdPatching\BmdObj.cs" />
     <Compile Include="Utilities\BmdPatching\BmdPatcher.cs" />
+    <Compile Include="Utilities\PackageUpdating\DownloadUtils\Zip7Extractor.cs" />
+    <Compile Include="Utilities\PackageUpdating\DownloadUtils\DownloadProgress.cs" />
+    <Compile Include="Utilities\PackageUpdating\StringConverters.cs" />
+    <Compile Include="Utilities\PackageUpdating\DownloadUtils\HttpClientExtensions.cs" />
+    <Compile Include="Utilities\PackageUpdating\DownloadUtils\StreamExtensions.cs" />
+    <Compile Include="Utilities\PackageUpdating\PackageUpdater.cs" />
+    <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItem.cs" />
+    <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemFile.cs" />
+    <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemUpdate.cs" />
+    <Compile Include="Utilities\PackageUpdating\UpdateStructures\GameBananaItemUpdateChange.cs" />
     <Compile Include="Utilities\PreappfileAppend.cs" />
     <Compile Include="Utilities\TblPatching\TblObj.cs" />
+    <Compile Include="Utilities\Windows\CategoryColourConverter.cs" />
+    <Compile Include="Utilities\Windows\TimeSinceConverter.cs" />
+    <Compile Include="Windows\ChangelogBox.xaml.cs">
+      <DependentUpon>ChangelogBox.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Windows\ConfigWindowP5.xaml.cs">
       <DependentUpon>ConfigWindowP5.xaml</DependentUpon>
     </Compile>
@@ -154,6 +175,19 @@
     <Compile Include="Windows\NotificationBox.xaml.cs">
       <DependentUpon>NotificationBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Windows\PackageFolderBox.xaml.cs">
+      <DependentUpon>PackageFolderBox.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\UpdateFileBox.xaml.cs">
+      <DependentUpon>UpdateFileBox.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\UpdateProgressBox.xaml.cs">
+      <DependentUpon>UpdateProgressBox.xaml</DependentUpon>
+    </Compile>
+    <Page Include="Windows\ChangelogBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Windows\ConfigWindowP5.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -194,6 +228,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Windows\NotificationBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Windows\PackageFolderBox.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Windows\UpdateFileBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Windows\UpdateProgressBox.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/AemulusModManager.sln
+++ b/AemulusModManager.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30406.217
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AemulusModManager", "AemulusModManager.csproj", "{C36E486D-E952-4E70-A55A-C3DF388A47C0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0E9DB59F-7F4E-49F5-94E2-68286B10885F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/App.config
+++ b/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/Utilities/BinMerging/BinMerger.cs
+++ b/Utilities/BinMerging/BinMerger.cs
@@ -4,11 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Input;
 
 namespace AemulusModManager
 {
@@ -139,7 +135,7 @@ namespace AemulusModManager
                 }
 
                 // Run prebuild.bat
-                if (File.Exists($@"{mod}\prebuild.bat") && new FileInfo($@"{mod}\prebuild.bat").Length > 0 )
+                if (File.Exists($@"{mod}\prebuild.bat") && new FileInfo($@"{mod}\prebuild.bat").Length > 0)
                 {
                     Console.WriteLine($@"[INFO] Running {mod}\prebuild.bat...");
 

--- a/Utilities/BinMerging/BinMerger.cs
+++ b/Utilities/BinMerging/BinMerger.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace AemulusModManager
 {
@@ -138,7 +139,7 @@ namespace AemulusModManager
                 if (File.Exists($@"{mod}\prebuild.bat") && new FileInfo($@"{mod}\prebuild.bat").Length > 0 )
                 {
                     Console.WriteLine($@"[INFO] Running {mod}\prebuild.bat...");
-                    
+
                     ProcessStartInfo ProcessInfo;
 
                     ProcessInfo = new ProcessStartInfo();
@@ -147,24 +148,18 @@ namespace AemulusModManager
                     ProcessInfo.UseShellExecute = false;
                     ProcessInfo.WorkingDirectory = Path.GetFullPath(mod);
 
-                    // *** Redirect the output ***
-                    ProcessInfo.RedirectStandardOutput = true;
-                    ProcessInfo.RedirectStandardError = true;
 
                     using (Process process = new Process())
                     {
                         process.StartInfo = ProcessInfo;
+
                         process.Start();
 
                         // Add this: wait until process does its work
                         process.WaitForExit();
-
-                        // *** Read the streams ***
-                        Console.Write(process.StandardOutput.ReadToEnd());
-                        Console.Write(process.StandardError.ReadToEnd());
                     }
 
-                    Console.WriteLine($@"Finished running {mod}\prebuild.bat!");
+                    Console.WriteLine($@"[INFO] Finished running {mod}\prebuild.bat!");
                 }
 
                 List<string> modList = getModList(mod);

--- a/Utilities/BinMerging/SprUtils.cs
+++ b/Utilities/BinMerging/SprUtils.cs
@@ -50,10 +50,10 @@ namespace AemulusModManager
             {
                 // Start search after "TMX0"
                 found = Search(SliceArray(sprBytes, offset, sprBytes.Length), pattern);
-                offset =  found + offset + 4;
+                offset = found + offset + 4;
                 if (found != -1)
                 {
-                    string tmxName = getTmxName(SliceArray(sprBytes,(offset + 24),sprBytes.Length));
+                    string tmxName = getTmxName(SliceArray(sprBytes, (offset + 24), sprBytes.Length));
                     if (!tmxNames.ContainsKey(tmxName))
                         tmxNames.Add(tmxName, offset - 12);
                 }

--- a/Utilities/BmdPatching/BmdObj.cs
+++ b/Utilities/BmdPatching/BmdObj.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace AemulusModManager.Utilities.BmdPatching
 {

--- a/Utilities/BmdPatching/BmdPatcher.cs
+++ b/Utilities/BmdPatching/BmdPatcher.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
-namespace AemulusModManager.Utilities.BmdPatching
+﻿namespace AemulusModManager.Utilities.BmdPatching
 {
     public static class BmdPatcher
     {

--- a/Utilities/PacUnpacker.cs
+++ b/Utilities/PacUnpacker.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.VisualBasic.FileIO;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 
@@ -81,8 +76,8 @@ namespace AemulusModManager
                 return;
             }
             List<string> pacs = new List<string>();
-            List<string> globs = new List<string>{"*[!0-9].bin", "*2[0-1][0-9].bin", "*.arc", "*.pac", "*.pack"};
-            switch(cpk)
+            List<string> globs = new List<string> { "*[!0-9].bin", "*2[0-1][0-9].bin", "*.arc", "*.pac", "*.pack" };
+            switch (cpk)
             {
                 case "data_e.cpk":
                     pacs.Add("data00004.pac");

--- a/Utilities/PackageUpdating/DownloadUtils/DownloadProgress.cs
+++ b/Utilities/PackageUpdating/DownloadUtils/DownloadProgress.cs
@@ -1,0 +1,18 @@
+﻿namespace AemulusModManager.Utilities.PackageUpdating.DownloadUtils
+{
+    public class DownloadProgress
+    {
+        public DownloadProgress(float percentage, long downloadedBytes, long totalBytes, string fileName)
+        {
+            DownloadedBytes = downloadedBytes;
+            TotalBytes = totalBytes;
+            Percentage = percentage;
+            FileName = fileName;
+        }
+
+        public float Percentage { get; set; }
+        public long DownloadedBytes { get; set; }
+        public long TotalBytes { get; set; }
+        public string FileName { get; set; }
+    }
+}

--- a/Utilities/PackageUpdating/DownloadUtils/HttpClientExtensions.cs
+++ b/Utilities/PackageUpdating/DownloadUtils/HttpClientExtensions.cs
@@ -1,0 +1,41 @@
+﻿using AemulusModManager.Utilities.PackageUpdating.DownloadUtils;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AemulusModManager
+{
+    // Taken from https://stackoverflow.com/a/46497896 
+    public static class HttpClientExtensions
+    {
+        public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, string fileName, IProgress<DownloadProgress> progress = null, CancellationToken cancellationToken = default)
+        {
+            // Get the http headers first to examine the content length
+            using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead))
+            {
+                var contentLength = response.Content.Headers.ContentLength;
+
+                using (var download = await response.Content.ReadAsStreamAsync())
+                {
+
+                    // Ignore progress reporting when no progress reporter was 
+                    // passed or when the content length is unknown
+                    if (progress == null || !contentLength.HasValue)
+                    {
+                        await download.CopyToAsync(destination);
+                        return;
+                    }
+
+                    // Convert absolute progress (bytes downloaded) into relative progress (0% - 100%)
+                    var relativeProgress = new Progress<long>(totalBytes => progress.Report(new DownloadProgress((float)totalBytes / contentLength.Value, totalBytes, contentLength.Value, fileName)));
+                    // Use extension method to report progress while downloading
+                    await download.CopyToAsync(destination, 81920, relativeProgress, cancellationToken);
+                    progress.Report(new DownloadProgress(1, contentLength.Value, contentLength.Value, fileName));
+                }
+            }
+        }
+    }
+
+}

--- a/Utilities/PackageUpdating/DownloadUtils/StreamExtensions.cs
+++ b/Utilities/PackageUpdating/DownloadUtils/StreamExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AemulusModManager
+{
+    // Taken from https://stackoverflow.com/a/46497896
+    public static class StreamExtensions
+    {
+        public static async Task CopyToAsync(this Stream source, Stream destination, int bufferSize, IProgress<long> progress = null, CancellationToken cancellationToken = default)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (!source.CanRead)
+                throw new ArgumentException("Has to be readable", nameof(source));
+            if (destination == null)
+                throw new ArgumentNullException(nameof(destination));
+            if (!destination.CanWrite)
+                throw new ArgumentException("Has to be writable", nameof(destination));
+            if (bufferSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize));
+
+            var buffer = new byte[bufferSize];
+            long totalBytesRead = 0;
+            int bytesRead;
+            while ((bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) != 0)
+            {
+                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                totalBytesRead += bytesRead;
+                progress?.Report(totalBytesRead);
+            }
+        }
+    }
+
+}

--- a/Utilities/PackageUpdating/DownloadUtils/Zip7Extractor.cs
+++ b/Utilities/PackageUpdating/DownloadUtils/Zip7Extractor.cs
@@ -1,0 +1,62 @@
+﻿using Onova.Services;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AemulusModManager.Utilities.PackageUpdating.DownloadUtils
+{
+    /// <summary>
+    /// Extracts files from 7z-archived packages.
+    /// </summary>
+    public class Zip7Extractor : IPackageExtractor
+    {
+        public async Task ExtractPackageAsync(string sourceFilePath, string destDirPath,
+            IProgress<double>? progress = null, CancellationToken cancellationToken = default)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.CreateNoWindow = false;
+            startInfo.FileName = @"Dependencies\7z\7z.exe";
+            if (!File.Exists(startInfo.FileName))
+            {
+                Console.WriteLine($"[ERROR] Couldn't find {startInfo.FileName}. Please check if it was blocked by your anti-virus.");
+                return;
+            }
+            // Extract the file
+            startInfo.Arguments = $"x -y \"{sourceFilePath}\" -o\"{destDirPath}\"";
+            Console.WriteLine($"[INFO] Extracting {sourceFilePath}");
+
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.UseShellExecute = false;
+
+            using (Process process = new Process())
+            {
+                process.StartInfo = startInfo;
+                process.Start();
+                Console.WriteLine(process.StandardOutput.ReadToEnd());
+                process.WaitForExit();
+            }
+            // TODO Check if it actually succeeded (by reading the command output I guess)
+            Console.WriteLine($"[INFO] Done Extracting {sourceFilePath}");
+            File.Delete(@$"{sourceFilePath}");
+            Console.WriteLine(@$"[INFO] Deleted {sourceFilePath}");
+            // Move the folders to the right place
+            string parentPath = Directory.GetParent(destDirPath).FullName;
+            Directory.Move(Directory.GetDirectories(destDirPath)[0], $@"{parentPath}\Aemulus");
+            Directory.Delete(destDirPath);
+            Directory.Move($@"{parentPath}\Aemulus", destDirPath);
+
+            /*    
+            // Rename the folder to version as this is what onva looks for
+                if (Directory.Exists(@$"{oldPath}\{game.Split(',')[1]}"))
+                {
+                    Directory.Delete(@$"{oldPath}\{game.Split(',')[1]}", true);
+                }
+                Directory.Move(Directory.GetDirectories(oldPath)[0], @$"{oldPath}\{game.Split(',')[1]}");
+            */
+        }
+
+    }
+}

--- a/Utilities/PackageUpdating/DownloadUtils/Zip7Extractor.cs
+++ b/Utilities/PackageUpdating/DownloadUtils/Zip7Extractor.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ namespace AemulusModManager.Utilities.PackageUpdating.DownloadUtils
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.CreateNoWindow = false;
-            startInfo.FileName = @"Dependencies\7z\7z.exe";
+            startInfo.FileName = @$"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Dependencies\7z\7z.exe";
             if (!File.Exists(startInfo.FileName))
             {
                 Console.WriteLine($"[ERROR] Couldn't find {startInfo.FileName}. Please check if it was blocked by your anti-virus.");
@@ -47,15 +48,6 @@ namespace AemulusModManager.Utilities.PackageUpdating.DownloadUtils
             Directory.Move(Directory.GetDirectories(destDirPath)[0], $@"{parentPath}\Aemulus");
             Directory.Delete(destDirPath);
             Directory.Move($@"{parentPath}\Aemulus", destDirPath);
-
-            /*    
-            // Rename the folder to version as this is what onva looks for
-                if (Directory.Exists(@$"{oldPath}\{game.Split(',')[1]}"))
-                {
-                    Directory.Delete(@$"{oldPath}\{game.Split(',')[1]}", true);
-                }
-                Directory.Move(Directory.GetDirectories(oldPath)[0], @$"{oldPath}\{game.Split(',')[1]}");
-            */
         }
 
     }

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -111,7 +111,7 @@ namespace AemulusModManager
                         onlineVersion = onlineVersionMatch.Value;
                     }
                     // GB Api only returns two latest updates, so if the first doesn't have a version try the second
-                    else if(updates.Length > 1)
+                    else if (updates.Length > 1)
                     {
                         updateTitle = updates[1].Title;
                         onlineVersionMatch = Regex.Match(updateTitle, @"(?<version>([1-9]+\.?)+)[^a-zA-Z]");
@@ -354,7 +354,7 @@ namespace AemulusModManager
             {
                 // Remove the file is it will be a partially downloaded one and close up
                 File.Delete(@$"Downloads\{fileName}");
-                if(progressBox != null)
+                if (progressBox != null)
                 {
                     progressBox.finished = true;
                     progressBox.Close();
@@ -364,7 +364,7 @@ namespace AemulusModManager
             catch (Exception e)
             {
                 Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}\n{e.StackTrace}");
-                if(progressBox != null)
+                if (progressBox != null)
                 {
                     progressBox.finished = true;
                     progressBox.Close();
@@ -412,7 +412,7 @@ namespace AemulusModManager
             {
                 // Remove the file is it will be a partially downloaded one and close up
                 File.Delete(@$"Downloads\AemulusUpdate\{fileName}");
-                if(progressBox != null)
+                if (progressBox != null)
                 {
                     progressBox.finished = true;
                     progressBox.Close();
@@ -422,7 +422,7 @@ namespace AemulusModManager
             catch (Exception e)
             {
                 Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}\n{e.StackTrace}");
-                if(progressBox != null)
+                if (progressBox != null)
                 {
                     progressBox.finished = true;
                     progressBox.Close();
@@ -485,7 +485,7 @@ namespace AemulusModManager
                 PackageFolderBox folderBox = new PackageFolderBox(packageRoots, packageName);
                 folderBox.Activate();
                 folderBox.ShowDialog();
-                if(folderBox.chosenFolder == null)
+                if (folderBox.chosenFolder == null)
                 {
                     Console.WriteLine($"[INFO] Cancelled update for {packageName}");
                     return;

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -85,7 +85,7 @@ namespace AemulusModManager
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[ERROR] Error whilst checking for updates: {e.Message}\n{e.StackTrace}");
+                Console.WriteLine($"[ERROR] Error whilst checking for updates: {e.Message}");
             }
         }
 
@@ -168,7 +168,7 @@ namespace AemulusModManager
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[ERROR] Error whilst checking for updates: {e.Message}\n{e.StackTrace}");
+                Console.WriteLine($"[ERROR] Error whilst checking for updates: {e.Message}");
             }
             return false;
         }
@@ -369,7 +369,7 @@ namespace AemulusModManager
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}\n{e.StackTrace}");
+                Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}");
                 if (progressBox != null)
                 {
                     progressBox.finished = true;
@@ -427,7 +427,7 @@ namespace AemulusModManager
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}\n{e.StackTrace}");
+                Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}");
                 if (progressBox != null)
                 {
                     progressBox.finished = true;

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -66,7 +66,7 @@ namespace AemulusModManager
                     {
                         for (int i = 0; i < gameBananaRows.Length; i++)
                         {
-                            await GameBananaUpdate(response[i], gameBananaRows[i], game, new Progress<DownloadProgress>(ReportUpdateProgress), cancellationToken);
+                            await GameBananaUpdate(response[i], gameBananaRows[i], game, new Progress<DownloadProgress>(ReportUpdateProgress), CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Token));
                         }
                     }
                 }
@@ -329,7 +329,7 @@ namespace AemulusModManager
                 }
                 if (downloadUrl != null && fileName != null)
                 {
-                    await DownloadFile(downloadUrl, fileName, game, row.path, row.name, progress, cancellationToken);
+                    await DownloadFile(downloadUrl, fileName, game, row.path, row.name, progress, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Token));
                 }
                 else
                 {

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -1,0 +1,531 @@
+﻿using AemulusModManager.Utilities.PackageUpdating;
+using AemulusModManager.Utilities.PackageUpdating.DownloadUtils;
+using AemulusModManager.Windows;
+using Newtonsoft.Json;
+using Octokit;
+using Onova;
+using Onova.Services;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AemulusModManager
+{
+    public class PackageUpdater
+    {
+        private readonly HttpClient client;
+        private GitHubClient gitHubClient;
+        private UpdateProgressBox progressBox;
+
+        public PackageUpdater()
+        {
+            client = new HttpClient();
+            gitHubClient = new GitHubClient(new ProductHeaderValue("Aemulus"));
+        }
+
+        public async Task CheckForUpdate(DisplayedMetadata[] rows, string game, CancellationTokenSource cancellationToken)
+        {
+            try
+            {
+                // Check GameBanana Items
+                DisplayedMetadata[] gameBananaRows = rows.Where(row => UrlConverter.Convert(row.link) == "GameBanana").ToArray();
+                if (gameBananaRows.Length > 0)
+                {
+
+                    string gameBananaRequestUrl = "https://api.gamebanana.com/Core/Item/Data?";
+                    // GameBanana
+                    foreach (DisplayedMetadata row in gameBananaRows)
+                    {
+                        // Convert the url
+                        Uri uri = CreateUri(row.link);
+                        string itemType = uri.Segments[1];
+                        itemType = char.ToUpper(itemType[0]) + itemType.Substring(1, itemType.Length - 3);
+                        string itemId = uri.Segments[2];
+                        gameBananaRequestUrl += $"itemtype[]={itemType}&itemid[]={itemId}&fields[]=Updates().bSubmissionHasUpdates(),Updates().aGetLatestUpdates(),Files().aFiles()&";
+                    }
+                    gameBananaRequestUrl += "return_keys=1";
+                    // Parse the response
+                    string responseString = await client.GetStringAsync(gameBananaRequestUrl);
+                    GameBananaItem[] response = JsonConvert.DeserializeObject<GameBananaItem[]>(responseString);
+                    if (response == null)
+                    {
+                        Console.WriteLine("[ERROR] Error whilst checking for package updates: No response from GameBanana API");
+                    }
+                    else
+                    {
+                        for (int i = 0; i < gameBananaRows.Length; i++)
+                        {
+                            await GameBananaUpdate(response[i], gameBananaRows[i], game, new Progress<DownloadProgress>(ReportUpdateProgress), cancellationToken);
+                        }
+                    }
+                }
+                // Check GitHub Items
+                DisplayedMetadata[] gitHubRows = rows.Where(row => UrlConverter.Convert(row.link) == "GitHub").ToArray();
+                if (gitHubRows.Length > 0)
+                {
+                    foreach (DisplayedMetadata row in gitHubRows)
+                    {
+                        Uri uri = CreateUri(row.link);
+                        Release latestRelease = await gitHubClient.Repository.Release.GetLatest(uri.Segments[1].Replace("/", ""), uri.Segments[2].Replace("/", ""));
+                        await GitHubUpdate(latestRelease, row, game, new Progress<DownloadProgress>(ReportUpdateProgress), cancellationToken);
+                    }
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                Console.WriteLine($"[ERROR] Connection error whilst checking for updates: {e.Message}");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[ERROR] Error whilst checking for updates: {e.Message}\n{e.StackTrace}");
+            }
+        }
+
+        public async Task<bool> CheckForAemulusUpdate(string aemulusVersion, CancellationTokenSource cancellationToken)
+        {
+            try
+            {
+
+                string requestUrl = $"https://api.gamebanana.com/Core/Item/Data?itemtype=Tool&itemid=6878&fields=Updates().bSubmissionHasUpdates(),Updates().aGetLatestUpdates(),Files().aFiles()&return_keys=1";
+                GameBananaItem response = JsonConvert.DeserializeObject<GameBananaItem>(await client.GetStringAsync(requestUrl));
+                if (response == null)
+                {
+                    Console.WriteLine("[ERROR] Error whilst checking for Aemulus update: No response from GameBanana API");
+                    return false;
+                }
+                if (response.HasUpdates)
+                {
+                    GameBananaItemUpdate[] updates = response.Updates;
+                    string updateTitle = updates[0].Title;
+                    Match onlineVersionMatch = Regex.Match(updateTitle, @"(?<version>([1-9]+\.?)+)[^a-zA-Z]");
+                    string onlineVersion = null;
+                    if (onlineVersionMatch.Success)
+                    {
+                        onlineVersion = onlineVersionMatch.Value;
+                    }
+                    if (UpdateAvailable(onlineVersion, aemulusVersion))
+                    {
+                        Console.WriteLine($"[INFO] An update is available for Aemulus ({onlineVersion})");
+                        ChangelogBox notification = new ChangelogBox(updates, "Aemulus", $"A new version of Aemulus is available (v{onlineVersion}), would you like to update now?", false);
+                        notification.ShowDialog();
+                        notification.Activate();
+                        if (notification.YesNo)
+                        {
+                            Console.WriteLine($"[INFO] Updating Aemulus to v{onlineVersion}");
+                            Dictionary<String, GameBananaItemFile> files = response.Files;
+                            string downloadUrl = files.ElementAt(0).Value.DownloadUrl;
+                            string fileName = files.ElementAt(0).Value.FileName;
+                            // Download the update
+                            await DownloadAemulus(downloadUrl, fileName, onlineVersion, new Progress<DownloadProgress>(ReportUpdateProgress), cancellationToken);
+                            // Notify that the update is about to happen
+                            NotificationBox finishedNotification = new NotificationBox($"Finished downloading {fileName}!\nAemulus will now restart.", true);
+                            finishedNotification.ShowDialog();
+                            finishedNotification.Activate();
+                            // Update Aemulus
+                            UpdateManager updateManager = new UpdateManager(new LocalPackageResolver(@"Downloads\AemulusUpdate"), new Zip7Extractor());
+                            if (!Version.TryParse(onlineVersion, out Version version))
+                            {
+                                Console.WriteLine("[ERROR] Error parsing Aemulus version, cancelling update");
+                                // TODO Delete the downloaded stuff
+                                return false;
+                            }
+                            // Updates and restarts Aemulus
+                            await updateManager.PrepareUpdateAsync(version);
+                            updateManager.LaunchUpdater(version);
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[INFO] No updates available for Aemulus");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine($"[INFO] No updates available for Aemulus");
+
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[ERROR] Error whilst checking for updates: {e.Message}\n{e.StackTrace}");
+            }
+            return false;
+        }
+
+        private void ReportUpdateProgress(DownloadProgress progress)
+        {
+            if (progress.Percentage == 1)
+            {
+                progressBox.finished = true;
+            }
+            progressBox.progressBar.Value = progress.Percentage * 100;
+            progressBox.taskBarItem.ProgressValue = progress.Percentage;
+            progressBox.progressText.Text = $"Downloading {progress.FileName}\n{Math.Round(progress.Percentage * 100, 2)}% ({StringConverters.FormatSize(progress.DownloadedBytes)} of {StringConverters.FormatSize(progress.TotalBytes)})";
+        }
+
+        private async Task GameBananaUpdate(GameBananaItem item, DisplayedMetadata row, string game, Progress<DownloadProgress> progress, CancellationTokenSource cancellationToken)
+        {
+            if (item.HasUpdates)
+            {
+                GameBananaItemUpdate[] updates = item.Updates;
+                string updateTitle = updates[0].Title;
+                Match onlineVersionMatch = Regex.Match(updateTitle, @"(?<version>([1-9]+\.?)+)[^a-zA-Z]");
+                string onlineVersion = null;
+                if (onlineVersionMatch.Success)
+                {
+                    onlineVersion = onlineVersionMatch.Value;
+                }
+                if (UpdateAvailable(onlineVersion, row.version))
+                {
+                    Console.WriteLine($"[INFO] An update is available for {row.name} ({onlineVersion})");
+                    // Display the changelog and confirm they want to update
+                    ChangelogBox changelogBox = new ChangelogBox(updates, row.name, $"Would you like to update {row.name} to version {onlineVersion}?", false);
+                    changelogBox.Activate();
+                    changelogBox.ShowDialog();
+                    if (!changelogBox.YesNo)
+                    {
+                        Console.WriteLine($"[INFO] Cancelled update for {row.name}");
+                        return;
+                    }
+                    // Download the update
+                    Dictionary<String, GameBananaItemFile> files = item.Files;
+                    string downloadUrl, fileName;
+                    if (files.Count > 1)
+                    {
+                        UpdateFileBox fileBox = new UpdateFileBox(files, row.name);
+                        fileBox.Activate();
+                        fileBox.ShowDialog();
+                        downloadUrl = fileBox.chosenFileUrl;
+                        fileName = fileBox.chosenFileName;
+                    }
+                    else if (files.Count == 1)
+                    {
+                        downloadUrl = files.ElementAt(0).Value.DownloadUrl;
+                        fileName = files.ElementAt(0).Value.FileName;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[INFO] An update is available for {row.name} ({onlineVersion}) but no downloadable files are available.");
+                        NotificationBox notification = new NotificationBox($"{row.name} has an update ({onlineVersion}) but no downloadable files.\nWould you like to go to the page to manually download the update?", false);
+                        notification.ShowDialog();
+                        notification.Activate();
+                        if (notification.YesNo)
+                        {
+                            Process.Start(row.link);
+                        }
+                        return;
+                    }
+                    if (downloadUrl != null && fileName != null)
+                    {
+                        await DownloadFile(downloadUrl, fileName, game, row.path, row.name, progress, cancellationToken);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[INFO] Cancelled update for {row.name}");
+                    }
+
+                }
+                else
+                {
+                    Console.WriteLine($"[INFO] No updates available for {row.name}");
+                }
+                // TODO Check if there was no version number
+            }
+            else
+            {
+                Console.WriteLine($"[INFO] No updates available for {row.name}");
+
+            }
+        }
+
+        private async Task GitHubUpdate(Release release, DisplayedMetadata row, string game, Progress<DownloadProgress> progress, CancellationTokenSource cancellationToken)
+        {
+            if (UpdateAvailable(release.TagName, row.version))
+            {
+                Console.WriteLine($"[INFO] An update is available for {row.name} ({release.TagName})");
+                string downloadUrl, fileName;
+                if (release.Assets.Count > 1)
+                {
+                    UpdateFileBox fileBox = new UpdateFileBox(release.Assets, row.name);
+                    fileBox.Activate();
+                    fileBox.ShowDialog();
+                    downloadUrl = fileBox.chosenFileUrl;
+                    fileName = fileBox.chosenFileName;
+                }
+                else if (release.Assets.Count == 1)
+                {
+                    downloadUrl = release.Assets.First().BrowserDownloadUrl;
+                    fileName = release.Assets.First().Name;
+                }
+                else
+                {
+                    Console.WriteLine($"[INFO] An update is available for {row.name} ({release.TagName}) but no downloadable files are available.");
+                    NotificationBox notification = new NotificationBox($"{row.name} has an update ({release.TagName}) but no downloadable files.\nWould you like to go to the page to manually download the update?", false);
+                    notification.ShowDialog();
+                    notification.Activate();
+                    if (notification.YesNo)
+                    {
+                        Process.Start(row.link);
+                    }
+                    return;
+                }
+                if (downloadUrl != null && fileName != null)
+                {
+                    await DownloadFile(downloadUrl, fileName, game, row.path, row.name, progress, cancellationToken);
+                }
+                else
+                {
+                    Console.WriteLine($"[INFO] Cancelled update for {row.name}");
+                }
+            }
+            else
+            {
+                Console.WriteLine($"[INFO] No updates available for {row.name}");
+            }
+        }
+
+        private async Task DownloadFile(string uri, string fileName, string game, string oldPath, string packageName, Progress<DownloadProgress> progress, CancellationTokenSource cancellationToken)
+        {
+            try
+            {
+                // Create the downloads folder if necessary
+                if (!Directory.Exists("Downloads"))
+                {
+                    Directory.CreateDirectory("Downloads");
+                }
+                // Download the file if it doesn't already exist
+                if (!File.Exists($"Downloads/{fileName}"))
+                {
+                    progressBox = new UpdateProgressBox(cancellationToken);
+                    progressBox.progressBar.Value = 0;
+                    progressBox.progressText.Text = $"Downloading {fileName}";
+                    progressBox.finished = false;
+                    progressBox.Title = $"{packageName} Update Progress";
+                    progressBox.Show();
+                    progressBox.Activate();
+                    Console.WriteLine($"[INFO] Downloading {fileName}");
+                    // Write and download the file
+                    using (var fs = new FileStream(
+                        $"Downloads/{fileName}", System.IO.FileMode.Create, FileAccess.Write, FileShare.None))
+                    {
+                        await client.DownloadAsync(uri, fs, fileName, progress, cancellationToken.Token);
+                    }
+                    Console.WriteLine($"[INFO] Finished downloading {fileName}");
+                    progressBox.Close();
+                }
+                else
+                {
+                    Console.WriteLine($"[INFO] {fileName} already exists in downloads, using this instead");
+                }
+                ExtractFile(fileName, game, oldPath, packageName);
+            }
+            catch (OperationCanceledException)
+            {
+                // Remove the file is it will be a partially downloaded one and close up
+                File.Delete(@$"Downloads\{fileName}");
+                if(progressBox != null)
+                {
+                    progressBox.finished = true;
+                    progressBox.Close();
+                }
+                return;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}\n{e.StackTrace}");
+                if(progressBox != null)
+                {
+                    progressBox.finished = true;
+                    progressBox.Close();
+                }
+            }
+        }
+
+        private async Task DownloadAemulus(string uri, string fileName, string version, Progress<DownloadProgress> progress, CancellationTokenSource cancellationToken)
+        {
+            try
+            {
+                // Create the downloads folder if necessary
+                if (!Directory.Exists("Downloads"))
+                {
+                    Directory.CreateDirectory("Downloads");
+                }
+                // Create the downloads folder if necessary
+                if (!Directory.Exists("Downloads/AemulusUpdate"))
+                {
+                    Directory.CreateDirectory("Downloads/AemulusUpdate");
+                }
+                progressBox = new UpdateProgressBox(cancellationToken);
+                progressBox.progressBar.Value = 0;
+                progressBox.progressText.Text = $"Downloading {fileName}";
+                progressBox.Title = "Aemulus Update Progress";
+                progressBox.finished = false;
+                progressBox.Show();
+                progressBox.Activate();
+                Console.WriteLine($"[INFO] Downloading {fileName}");
+                // Write and download the file
+                using (var fs = new FileStream(
+                    $"Downloads/AemulusUpdate/{fileName}", System.IO.FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    await client.DownloadAsync(uri, fs, fileName, progress, cancellationToken.Token);
+                }
+                Console.WriteLine($"[INFO] Finished downloading {fileName}");
+                // Rename the file
+                if (!File.Exists($@"Downloads/AemulusUpdate/{version}.7z"))
+                {
+                    File.Move($@"Downloads/AemulusUpdate/{fileName}", $@"Downloads/AemulusUpdate/{version}.7z");
+                }
+                progressBox.Close();
+            }
+            catch (OperationCanceledException)
+            {
+                // Remove the file is it will be a partially downloaded one and close up
+                File.Delete(@$"Downloads\AemulusUpdate\{fileName}");
+                if(progressBox != null)
+                {
+                    progressBox.finished = true;
+                    progressBox.Close();
+                }
+                return;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[ERROR] Error whilst downloading {fileName}: {e.Message}\n{e.StackTrace}");
+                if(progressBox != null)
+                {
+                    progressBox.finished = true;
+                    progressBox.Close();
+                }
+            }
+        }
+
+        private void ExtractFile(string fileName, string game, string oldPath, string packageName)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.CreateNoWindow = false;
+            startInfo.FileName = @"Dependencies\7z\7z.exe";
+            if (!File.Exists(startInfo.FileName))
+            {
+                Console.WriteLine($"[ERROR] Couldn't find {startInfo.FileName}. Please check if it was blocked by your anti-virus.");
+                return;
+            }
+            // Extract the file
+            startInfo.Arguments = $"x -y \"Downloads\\{fileName}\" -o\"Downloads\\{packageName}\"";
+            Console.WriteLine($"[INFO] Extracting {fileName}");
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.UseShellExecute = false;
+
+            using (Process process = new Process())
+            {
+                process.StartInfo = startInfo;
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd();
+                if (output.Contains("Everything is Ok"))
+                {
+                    Console.WriteLine($"[INFO] Done Extracting {fileName}");
+                }
+                else
+                {
+                    Console.WriteLine($"[ERROR] There was an error extracting {fileName}:\n{output}");
+                    // Remove the download as it is likely corrupted
+                    File.Delete(@$"Downloads\{fileName}");
+                    if (Directory.Exists($@"Downloads\{packageName}"))
+                    {
+                        Directory.Delete($@"Downloads\{packageName}", true);
+                    }
+                    Console.WriteLine(@$"[INFO] Cleaned up {packageName} download files");
+                    return;
+                }
+                process.WaitForExit();
+            }
+            // Find the root and move the extracted file to the correct package folder
+            string[] packageRoots = Array.ConvertAll(Directory.GetFiles(@$"Downloads\{packageName}", "Package.xml", SearchOption.AllDirectories), path => Path.GetDirectoryName(path));
+            if (packageRoots.Length == 1)
+            {
+                // Remove the old package directory
+                Directory.Delete($@"Packages\{game}\{oldPath}", true);
+                Console.WriteLine($@"[INFO] Deleted old installation (Packages\{game}\{oldPath})");
+                Directory.Move(packageRoots[0], $@"Packages\{game}\{oldPath}");
+            }
+            else if (packageRoots.Length > 1)
+            {
+                // Open a dialog asking which folder to use
+                PackageFolderBox folderBox = new PackageFolderBox(packageRoots, packageName);
+                folderBox.Activate();
+                folderBox.ShowDialog();
+                if(folderBox.chosenFolder == null)
+                {
+                    Console.WriteLine($"[INFO] Cancelled update for {packageName}");
+                    return;
+                }
+                // Remove the old package directory
+                Directory.Delete($@"Packages\{game}\{oldPath}", true);
+                Console.WriteLine($@"[INFO] Deleted old installation (Packages\{game}\{oldPath})");
+                Directory.Move(folderBox.chosenFolder, $@"Packages\{game}\{oldPath}");
+            }
+            else
+            {
+                Console.WriteLine($"[ERROR] {fileName} does not contain a valid package (no Package.xml is present), ignoring it");
+            }
+            File.Delete(@$"Downloads\{fileName}");
+            if (Directory.Exists($@"Downloads\{packageName}"))
+            {
+                Directory.Delete($@"Downloads\{packageName}", true);
+            }
+            Console.WriteLine(@$"[INFO] Cleaned up {packageName} download files");
+        }
+
+        private bool UpdateAvailable(string onlineVersion, string localVersion)
+        {
+            if (onlineVersion is null)
+            {
+                return false;
+            }
+            string[] onlineVersionParts = onlineVersion.Split('.');
+            string[] localVersionParts = localVersion.Split('.');
+            // Pad the version if one has more parts than another (e.g. 1.2.1 and 1.2)
+            if (onlineVersionParts.Length > localVersionParts.Length)
+            {
+                for (int i = localVersionParts.Length; i < onlineVersionParts.Length; i++)
+                {
+                    localVersionParts = localVersionParts.Append("0").ToArray();
+                }
+            }
+            else if (localVersionParts.Length > onlineVersionParts.Length)
+            {
+                for (int i = onlineVersionParts.Length; i < localVersionParts.Length; i++)
+                {
+                    onlineVersionParts = onlineVersionParts.Append("0").ToArray();
+                }
+            }
+            // Decide whether the online version is new than local
+            for (int i = 0; i < onlineVersionParts.Length; i++)
+            {
+                if (int.Parse(onlineVersionParts[i]) > int.Parse(localVersionParts[i]))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private Uri CreateUri(string url)
+        {
+            Uri uri;
+            if ((Uri.TryCreate(url, UriKind.Absolute, out uri) || Uri.TryCreate("http://" + url, UriKind.Absolute, out uri)) &&
+                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            {
+                return uri;
+            }
+            return null;
+        }
+    }
+}

--- a/Utilities/PackageUpdating/StringConverters.cs
+++ b/Utilities/PackageUpdating/StringConverters.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace AemulusModManager.Utilities.PackageUpdating
+{
+    class StringConverters
+    {
+        // Load all suffixes in an array  
+        static readonly string[] suffixes =
+        { "Bytes", "KB", "MB", "GB", "TB", "PB" };
+        public static string FormatSize(long bytes)
+        {
+            int counter = 0;
+            decimal number = (decimal)bytes;
+            while (Math.Round(number / 1024) >= 1)
+            {
+                number = number / 1024;
+                counter++;
+            }
+            return string.Format("{0:n1}{1}", number, suffixes[counter]);
+        }
+
+        public static string FormatTimeSpan(TimeSpan timeSpan)
+        {
+            if (timeSpan.TotalMinutes < 60)
+            {
+                return Math.Floor(timeSpan.TotalMinutes).ToString() + "min";
+            }
+            else if (timeSpan.TotalHours < 24)
+            {
+                return Math.Floor(timeSpan.TotalHours).ToString() + "hr";
+            }
+            else if (timeSpan.TotalDays < 7)
+            {
+                return Math.Floor(timeSpan.TotalDays).ToString() + "d";
+            }
+            else if (timeSpan.TotalDays < 30.4)
+            {
+                return Math.Floor(timeSpan.TotalDays / 7).ToString() + "wk";
+            }
+            else if (timeSpan.TotalDays < 365.25)
+            {
+                return Math.Floor(timeSpan.TotalDays / 30.4).ToString() + "mo";
+            }
+            else
+            {
+                return Math.Floor(timeSpan.TotalDays % 365.25).ToString() + "yr";
+            }
+        }
+    }
+}
+

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItem.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItem.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace AemulusModManager
+{
+    /* Disclaimer: These classes are taken (slightly modified) from Reloaded II's Gamebanana Resolver*/
+    class GameBananaItem
+    {
+        [JsonProperty("Updates().bSubmissionHasUpdates()")]
+        public bool HasUpdates { get; set; }
+
+        [JsonProperty("Updates().aGetLatestUpdates()")]
+        public GameBananaItemUpdate[] Updates { get; set; }
+
+        [JsonProperty("Files().aFiles()")]
+        public Dictionary<string, GameBananaItemFile> Files { get; set; }
+
+    }
+}

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFile.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFile.cs
@@ -1,4 +1,5 @@
 ﻿using AemulusModManager.Utilities.PackageUpdating;
+using AemulusModManager.Utilities.PackageUpdating.UpdateStructures;
 using Newtonsoft.Json;
 using System;
 
@@ -22,6 +23,9 @@ namespace AemulusModManager
 
         [JsonProperty("_tsDateAdded")]
         public long DateAddedLong { get; set; }
+
+        [JsonProperty("_aMetadata")]
+        public GameBananaItemFileMetadata FileMetadata { get; set; }
 
         [JsonIgnore]
         public DateTime DateAdded => Epoch.AddSeconds(DateAddedLong);

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFile.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFile.cs
@@ -1,0 +1,33 @@
+﻿using AemulusModManager.Utilities.PackageUpdating;
+using Newtonsoft.Json;
+using System;
+
+namespace AemulusModManager
+{
+    public class GameBananaItemFile
+    {
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1);
+
+        [JsonProperty("_sFile")]
+        public string FileName { get; set; }
+
+        [JsonProperty("_nFilesize")]
+        public long Filesize { get; set; }
+
+        [JsonProperty("_sDownloadUrl")]
+        public string DownloadUrl { get; set; }
+
+        [JsonProperty("_sDescription")]
+        public string Description { get; set; }
+
+        [JsonProperty("_tsDateAdded")]
+        public long DateAddedLong { get; set; }
+
+        [JsonIgnore]
+        public DateTime DateAdded => Epoch.AddSeconds(DateAddedLong);
+
+        [JsonIgnore]
+        public string TimeSinceUpload => StringConverters.FormatTimeSpan(DateTime.UtcNow - DateAdded);
+    }
+
+}

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFileMetadata.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFileMetadata.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace AemulusModManager.Utilities.PackageUpdating.UpdateStructures
+{
+    public class GameBananaItemFileMetadata
+    {
+        [JsonProperty("_sMimeType")]
+        public string FileType { set; get; }
+
+        [JsonProperty("_aArchiveFileTree")]
+        [JsonExtensionData]
+        public IDictionary<string, JToken> FileTree { get; set; }
+    }
+}

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFileTree.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItemFileTree.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace AemulusModManager.Utilities.PackageUpdating.UpdateStructures
+{
+    public class GameBananaItemFileTree
+    {
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Contents { get; set; }
+    }
+}

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItemUpdate.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItemUpdate.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace AemulusModManager
+{
+    public class GameBananaItemUpdate
+    {
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1);
+
+        [JsonProperty("_sTitle")]
+        public string Title { get; set; }
+
+        [JsonProperty("_aChangeLog")]
+        public GameBananaItemUpdateChange[] Changes { get; set; }
+
+        [JsonProperty("_sText")]
+        public string Text { get; set; }
+
+        [JsonProperty("_tsDateAdded")]
+        public long DateAddedLong { get; set; }
+
+        [JsonIgnore]
+        public DateTime DateAdded => Epoch.AddSeconds(DateAddedLong);
+    }
+}

--- a/Utilities/PackageUpdating/UpdateStructures/GameBananaItemUpdateChange.cs
+++ b/Utilities/PackageUpdating/UpdateStructures/GameBananaItemUpdateChange.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace AemulusModManager
+{
+    public class GameBananaItemUpdateChange
+    {
+        [JsonProperty("cat")]
+        public string Category { get; set; }
+
+        [JsonProperty("text")]
+        public string Text { get; set; }
+    }
+
+}

--- a/Utilities/PreappfileAppend.cs
+++ b/Utilities/PreappfileAppend.cs
@@ -92,8 +92,13 @@ namespace AemulusModManager
                 {
                     process.StartInfo = startInfo;
                     process.Start();
-                    Console.Write(process.StandardOutput.ReadToEnd());
-                    process.WaitForExit();
+                    while (!process.HasExited)
+                    {
+                        string text = process.StandardOutput.ReadLine();
+                        if (text != "" && text != null)
+                            Console.WriteLine($"[INFO] {text}");
+                    }
+                    //process.WaitForExit();
                 }
             }
             if (Directory.Exists($@"{path}\mods\preappfile\movie"))
@@ -104,8 +109,13 @@ namespace AemulusModManager
                 {
                     process.StartInfo = startInfo;
                     process.Start();
-                    Console.Write(process.StandardOutput.ReadToEnd());
-                    process.WaitForExit();
+                    while (!process.HasExited)
+                    {
+                        string text = process.StandardOutput.ReadLine();
+                        if (text != "" && text != null)
+                            Console.WriteLine($"[INFO] {text}");
+                    }
+                    //process.WaitForExit();
                 }
             }
         }

--- a/Utilities/PreappfileAppend.cs
+++ b/Utilities/PreappfileAppend.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Security.Cryptography;
 using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
 
 namespace AemulusModManager
 {
@@ -37,7 +33,7 @@ namespace AemulusModManager
                 Console.WriteLine($@"[ERROR] Couldn't find Dependencies\preappfile\preappfile.exe. Please check if it was blocked by your anti-virus.");
                 return;
             }
-            
+
             if (!File.Exists($@"{path}\{cpkLang}"))
             {
                 Console.WriteLine($@"[ERROR] Couldn't find {path}\{cpkLang} for appending.");

--- a/Utilities/TblPatching/TblPatch.cs
+++ b/Utilities/TblPatching/TblPatch.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using AemulusModManager.Utilities.TblPatching;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Diagnostics;
-using AemulusModManager.Utilities.TblPatching;
-using Newtonsoft.Json;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace AemulusModManager
@@ -21,7 +21,7 @@ namespace AemulusModManager
             Array.Copy(source, start, dest, 0, length);
             return dest;
         }
-        
+
         private static void unpackTbls(string archive, string game)
         {
             if (game == "Persona 3 FES")
@@ -119,7 +119,7 @@ namespace AemulusModManager
                         return;
                     }
                 }
-            
+
                 tblDir = $@"{modDir}\{Path.ChangeExtension(archive, null)}_tbls";
                 // Unpack archive
                 Console.WriteLine($"[INFO] Unpacking TBLs from {archive}...");
@@ -294,7 +294,7 @@ namespace AemulusModManager
                             continue;
                     }
 
-                    
+
 
                     // Keep track of which TBL's were edited
                     if (!editedTables.Contains(tblName))
@@ -367,7 +367,7 @@ namespace AemulusModManager
                         }
                     }
                 }
-                
+
                 List<Table> tables = new List<Table>();
                 // Apply new tbp json patching
                 foreach (var t in Directory.GetFiles($@"{dir}\tblpatches", "*.tbp"))
@@ -458,9 +458,9 @@ namespace AemulusModManager
                 }
 
                 Console.WriteLine($"[INFO] Applied patches from {dir}");
-                
+
             }
-            
+
             if (game != "Persona 3 FES")
             {
                 // Replace each edited TBL's

--- a/Utilities/Windows/CategoryColourConverter.cs
+++ b/Utilities/Windows/CategoryColourConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace AemulusModManager.Utilities.Windows
+{
+    public class CategoryColourConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            switch ((string)value)
+            {
+                case "BugFix":
+                    return new SolidColorBrush(Color.FromRgb(255, 78, 78));
+                case "Overhaul":
+                    return new SolidColorBrush(Color.FromRgb(255, 78, 78));
+                case "Addition":
+                    return new SolidColorBrush(Color.FromRgb(108, 177, 255));
+                case "Feature":
+                    return new SolidColorBrush(Color.FromRgb(108, 177, 255));
+                case "Tweak":
+                    return new SolidColorBrush(Color.FromRgb(255, 94, 157));
+                case "Improvement":
+                    return new SolidColorBrush(Color.FromRgb(255, 94, 157));
+                case "Optimization":
+                    return new SolidColorBrush(Color.FromRgb(255, 94, 157));
+                case "Adjustment":
+                    return new SolidColorBrush(Color.FromRgb(110, 255, 108));
+                case "Suggestion":
+                    return new SolidColorBrush(Color.FromRgb(110, 255, 108));
+                case "Ammendment":
+                    return new SolidColorBrush(Color.FromRgb(110, 255, 108));
+                case "Removal":
+                    return new SolidColorBrush(Color.FromRgb(153, 153, 153));
+                case "Refactor":
+                    return new SolidColorBrush(Color.FromRgb(153, 153, 153));
+                default:
+                    return new SolidColorBrush(Color.FromRgb(0, 0, 0));
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -35,9 +35,12 @@ namespace AemulusModManager
         public string reloadedPath { get; set; }
         public bool emptySND { get; set; }
         public bool useCpk { get; set; }
-        public bool disableMessageBox { get; set; }
         public string cpkLang { get; set; }
         public bool deleteOldVersions { get; set; }
+        public bool buildWarning { get; set; }
+        public bool buildFinished { get; set; }
+        public bool updateConfirm { get; set; }
+        public bool updateChangelog { get; set; }
     }
 
     public class ConfigP3F
@@ -46,7 +49,10 @@ namespace AemulusModManager
         public string isoPath { get; set; }
         public string elfPath { get; set; }
         public string launcherPath { get; set; }
-        public bool disableMessageBox { get; set; }
+        public bool buildWarning { get; set; }
+        public bool buildFinished { get; set; }
+        public bool updateConfirm { get; set; }
+        public bool updateChangelog { get; set; }
         public bool advancedLaunchOptions { get; set; }
         public bool deleteOldVersions { get; set; }
     }
@@ -56,7 +62,10 @@ namespace AemulusModManager
         public string modDir { get; set; }
         public string gamePath { get; set; }
         public string launcherPath { get; set; }
-        public bool disableMessageBox { get; set; }
+        public bool buildWarning { get; set; }
+        public bool buildFinished { get; set; }
+        public bool updateConfirm { get; set; }
+        public bool updateChangelog { get; set; }
         public bool deleteOldVersions { get; set; }
     }
 

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.Windows.Documents;
 using System.Xml.Serialization;
 
 namespace AemulusModManager

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -41,6 +41,7 @@ namespace AemulusModManager
         public bool buildFinished { get; set; } = true;
         public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
+        public bool updateAll { get; set; } = true;
     }
 
     public class ConfigP3F
@@ -53,6 +54,7 @@ namespace AemulusModManager
         public bool buildFinished { get; set; } = true;
         public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
+        public bool updateAll { get; set; } = true;
         public bool advancedLaunchOptions { get; set; }
         public bool deleteOldVersions { get; set; }
     }
@@ -66,6 +68,7 @@ namespace AemulusModManager
         public bool buildFinished { get; set; } = true;
         public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
+        public bool updateAll { get; set; } = true;
         public bool deleteOldVersions { get; set; }
     }
 

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -37,10 +37,10 @@ namespace AemulusModManager
         public bool useCpk { get; set; }
         public string cpkLang { get; set; }
         public bool deleteOldVersions { get; set; }
-        public bool buildWarning { get; set; }
-        public bool buildFinished { get; set; }
-        public bool updateConfirm { get; set; }
-        public bool updateChangelog { get; set; }
+        public bool buildWarning { get; set; } = true;
+        public bool buildFinished { get; set; } = true;
+        public bool updateConfirm { get; set; } = true;
+        public bool updateChangelog { get; set; } = true;
     }
 
     public class ConfigP3F
@@ -49,10 +49,10 @@ namespace AemulusModManager
         public string isoPath { get; set; }
         public string elfPath { get; set; }
         public string launcherPath { get; set; }
-        public bool buildWarning { get; set; }
-        public bool buildFinished { get; set; }
-        public bool updateConfirm { get; set; }
-        public bool updateChangelog { get; set; }
+        public bool buildWarning { get; set; } = true;
+        public bool buildFinished { get; set; } = true;
+        public bool updateConfirm { get; set; } = true;
+        public bool updateChangelog { get; set; } = true;
         public bool advancedLaunchOptions { get; set; }
         public bool deleteOldVersions { get; set; }
     }
@@ -62,10 +62,10 @@ namespace AemulusModManager
         public string modDir { get; set; }
         public string gamePath { get; set; }
         public string launcherPath { get; set; }
-        public bool buildWarning { get; set; }
-        public bool buildFinished { get; set; }
-        public bool updateConfirm { get; set; }
-        public bool updateChangelog { get; set; }
+        public bool buildWarning { get; set; } = true;
+        public bool buildFinished { get; set; } = true;
+        public bool updateConfirm { get; set; } = true;
+        public bool updateChangelog { get; set; } = true;
         public bool deleteOldVersions { get; set; }
     }
 

--- a/Utilities/Windows/TextBoxOutputter.cs
+++ b/Utilities/Windows/TextBoxOutputter.cs
@@ -52,7 +52,10 @@ namespace AemulusModManager
         {
             WriteLineEvent?.Invoke(this, new ConsoleWriterEventArgs(value));
             base.WriteLine(value);
-            sw.WriteLine(value);
+            if (sw != null)
+            {
+                sw.WriteLine(value);
+            }
         }
 
         // Make sure you call this before you end

--- a/Utilities/Windows/TimeSinceConverter.cs
+++ b/Utilities/Windows/TimeSinceConverter.cs
@@ -1,0 +1,20 @@
+﻿using AemulusModManager.Utilities.PackageUpdating;
+using System;
+using System.Windows.Data;
+
+namespace AemulusModManager.Utilities.Windows
+{
+    public class TimeSinceConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return StringConverters.FormatTimeSpan(DateTime.UtcNow - (DateTimeOffset)value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+
+    }
+}

--- a/Utilities/Windows/UrlConverter.cs
+++ b/Utilities/Windows/UrlConverter.cs
@@ -42,5 +42,37 @@ namespace AemulusModManager
         {
             throw new NotImplementedException();
         }
+
+        public static string Convert(string url)
+        {
+            if (url == null || url.Length == 0)
+                return null;
+            Uri uri;
+            if ((Uri.TryCreate(url, UriKind.Absolute, out uri) || Uri.TryCreate("http://" + url, UriKind.Absolute, out uri)) &&
+                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            {
+                // Use validated URI here
+                string host = uri.DnsSafeHost;
+                switch (host)
+                {
+                    case "www.gamebanana.com":
+                    case "gamebanana.com":
+                        return "GameBanana";
+                    case "nexusmods.com":
+                    case "www.nexusmods.com":
+                        return "Nexus";
+                    case "www.shrinefox.com":
+                    case "shrinefox.com":
+                        return "ShrineFox";
+                    case "www.github.com":
+                    case "github.com":
+                        return "GitHub";
+                    default:
+                        return "Other";
+                }
+            }
+            return null;
+        }
+
     }
 }

--- a/Windows/ChangelogBox.xaml
+++ b/Windows/ChangelogBox.xaml
@@ -1,0 +1,52 @@
+﻿<Window x:Class="AemulusModManager.Windows.ChangelogBox"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AemulusModManager.Windows" xmlns:local1="clr-namespace:AemulusModManager.Utilities.Windows"
+        mc:Ignorable="d"
+        Title="Changelog"
+        Background="#121212" ShowActivated="True" SizeToContent="WidthAndHeight" ResizeMode="NoResize">
+    <Window.Resources>
+        <local1:CategoryColourConverter x:Key="CategoryColourConverter"/>
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" x:Name="Text" Padding="10" Foreground="White" TextAlignment="Center" VerticalAlignment="Center" TextWrapping="WrapWithOverflow" FontSize="15"/>
+        <Label Grid.Row="1" x:Name="VersionLabel" Content="Version" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10, 10, 10, 0" FontSize="17" Foreground="White"/>
+        <DataGrid Grid.Row="2" x:Name="ChangesGrid" HorizontalAlignment="Center" Margin="25,0, 25, 10" RowBackground="#121212" BorderBrush="Transparent" Foreground="White" 
+                  VerticalAlignment="Center" FontSize="13" HeadersVisibility="None" AutoGenerateColumns="False" 
+                  HorizontalScrollBarVisibility="Disabled" GridLinesVisibility="None" IsHitTestVisible="False">
+            <DataGrid.Columns>
+                <DataGridTemplateColumn IsReadOnly="True">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Label 
+                            Content="{Binding Category}"
+                            Foreground="{Binding Category, Converter={StaticResource CategoryColourConverter}}"
+                            FontSize="15"
+                            Background="#121212"
+                            />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn IsReadOnly="True" Binding="{Binding Text}" MaxWidth="300">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style>
+                            <Setter Property="TextBlock.TextWrapping" Value="Wrap" />
+                            <Setter Property="TextBlock.VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+        <Button x:Name="OkButton" Content="OK" Visibility="Collapsed" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Button_Click" IsDefault="True" Grid.Row="3" Margin="0,0,22,10"/>
+        <Button x:Name="YesButton" Visibility="Collapsed" Content="Yes" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Yes_Button_Click" IsDefault="True" Grid.Row="3" Margin="0,0,130,14"/>
+        <Button x:Name="NoButton" Visibility="Collapsed" Content="No" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Button_Click" Grid.Row="3" Margin="100,0,22,14"/>
+    </Grid>
+</Window>

--- a/Windows/ChangelogBox.xaml.cs
+++ b/Windows/ChangelogBox.xaml.cs
@@ -11,12 +11,12 @@ namespace AemulusModManager.Windows
     public partial class ChangelogBox : Window
     {
         public bool YesNo = false;
-        public ChangelogBox(GameBananaItemUpdate[] updates, string packageName, string text, bool OK = true)
+        public ChangelogBox(GameBananaItemUpdate update, string packageName, string text, bool OK = true)
         {
             InitializeComponent();
-            ChangesGrid.ItemsSource = updates[0].Changes;
+            ChangesGrid.ItemsSource = update.Changes;
             Title = $"{packageName} Changelog";
-            VersionLabel.Content = updates[0].Title;
+            VersionLabel.Content = update.Title;
             Text.Text = text;
             if (OK)
             {

--- a/Windows/ChangelogBox.xaml.cs
+++ b/Windows/ChangelogBox.xaml.cs
@@ -2,40 +2,38 @@
 using System;
 using System.Media;
 using System.Windows;
-using System.Windows.Shell;
 
-namespace AemulusModManager
+namespace AemulusModManager.Windows
 {
     /// <summary>
-    /// Interaction logic for NotificationBox.xaml
+    /// Interaction logic for ChangelogBox.xaml
     /// </summary>
-    public partial class NotificationBox : Window
+    public partial class ChangelogBox : Window
     {
         public bool YesNo = false;
-        public NotificationBox(string message, bool OK = true)
+        public ChangelogBox(GameBananaItemUpdate[] updates, string packageName, string text, bool OK = true)
         {
             InitializeComponent();
-            Notification.Text = message;
+            ChangesGrid.ItemsSource = updates[0].Changes;
+            Title = $"{packageName} Changelog";
+            VersionLabel.Content = updates[0].Title;
+            Text.Text = text;
             if (OK)
             {
                 OkButton.Visibility = Visibility.Visible;
-                PlayNotificationSound();
-                taskBarItem.ProgressState = TaskbarItemProgressState.Indeterminate;
             }
             else
             {
                 YesButton.Visibility = Visibility.Visible;
                 NoButton.Visibility = Visibility.Visible;
             }
-            if (message.Length > 40)
-                Notification.TextAlignment = TextAlignment.Left;
+            PlayNotificationSound();
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             Close();
         }
-
         private void Yes_Button_Click(object sender, RoutedEventArgs e)
         {
             YesNo = true;

--- a/Windows/ConfigWindowP3F.xaml
+++ b/Windows/ConfigWindowP3F.xaml
@@ -45,8 +45,9 @@
             <TextBlock Text="Prompt for Extra Options when Launching" Foreground="White" FontSize="13"/>
         </CheckBox>
         
-        <Grid Grid.Row="8" Grid.Column="2">
+        <Grid Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="3">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -66,6 +67,14 @@
                     <TextBlock TextAlignment="Center">
                         Delete Old<LineBreak/>
                         Versions
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="3">
+                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked">
+                    <TextBlock TextAlignment="Center">
+                        Update All<LineBreak/>
+                        On Refresh
                     </TextBlock>
                 </CheckBox>
             </Viewbox>

--- a/Windows/ConfigWindowP3F.xaml
+++ b/Windows/ConfigWindowP3F.xaml
@@ -53,12 +53,13 @@
             </Grid.ColumnDefinitions>
             <Button Height="30" Width="110" Content="Unpack Base Files" Name="UnpackButton" Grid.Column="0" Click="UnpackPacsClick" Background ="White" VerticalAlignment="Center"/>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="1">
-                <CheckBox Name="NotifBox" Foreground ="White" Checked="NotifChecked" Unchecked="NotifUnchecked">
-                    <TextBlock TextAlignment="Center">
-                        Disable<LineBreak/>
-                        Notification
-                    </TextBlock>
-                </CheckBox>
+                <ComboBox x:Name="NotifBox" Width="120" FontSize="15" Text="Notifications" SelectedIndex="0" SelectionChanged="NotifBox_SelectionChanged">
+                    <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
+                    <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
+                    <CheckBox x:Name="BuildFinishedBox" Content="Build Finished" Checked="BuildFinishedChecked" Unchecked="BuildFinishedUnchecked"/>
+                    <CheckBox x:Name="ConfirmUpdateBox" Content="Confirm Update" Checked="ConfirmUpdateChecked" Unchecked="ConfirmUpdateUnchecked"/>
+                    <CheckBox x:Name="ChangelogBox" Content="Update Changelog" Checked="ChangelogChecked" Unchecked="ChangelogUnchecked"/>
+                </ComboBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="2">
                 <CheckBox Name="DeleteBox" Foreground ="White" Checked="DeleteChecked" Unchecked="DeleteUnchecked">

--- a/Windows/ConfigWindowP3F.xaml.cs
+++ b/Windows/ConfigWindowP3F.xaml.cs
@@ -29,7 +29,10 @@ namespace AemulusModManager
             if (main.elfPath != null)
                 ELFTextbox.Text = main.elfPath;
             AdvancedLaunchOptions.IsChecked = main.config.p3fConfig.advancedLaunchOptions;
-            NotifBox.IsChecked = main.config.p3fConfig.disableMessageBox;
+            BuildFinishedBox.IsChecked = main.config.p3fConfig.buildFinished;
+            BuildWarningBox.IsChecked = main.config.p3fConfig.buildWarning;
+            ConfirmUpdateBox.IsChecked = main.config.p3fConfig.updateConfirm;
+            ChangelogBox.IsChecked = main.config.p3fConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p3fConfig.deleteOldVersions;
             Console.WriteLine("[INFO] Config launched");
         }
@@ -49,16 +52,53 @@ namespace AemulusModManager
             }
         }
 
-        private void NotifChecked(object sender, RoutedEventArgs e)
+        private void BuildWarningChecked(object sender, RoutedEventArgs e)
         {
-            main.messageBox = true;
-            main.config.p3fConfig.disableMessageBox = true;
+            main.buildWarning = true;
+            main.config.p3fConfig.buildWarning = true;
             main.updateConfig();
         }
-        private void NotifUnchecked(object sender, RoutedEventArgs e)
+
+        private void BuildWarningUnchecked(object sender, RoutedEventArgs e)
         {
-            main.messageBox = false;
-            main.config.p3fConfig.disableMessageBox = false;
+            main.buildWarning = false;
+            main.config.p3fConfig.buildWarning = false;
+            main.updateConfig();
+        }
+        private void BuildFinishedChecked(object sender, RoutedEventArgs e)
+        {
+            main.buildFinished = true;
+            main.config.p3fConfig.buildFinished = true;
+            main.updateConfig();
+        }
+        private void BuildFinishedUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.buildFinished = false;
+            main.config.p3fConfig.buildFinished = false;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = true;
+            main.config.p3fConfig.updateConfirm = true;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = false;
+            main.config.p3fConfig.updateConfirm = false;
+            main.updateConfig();
+        }
+        private void ChangelogChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateChangelog = true;
+            main.config.p3fConfig.updateChangelog = true;
+            main.updateConfig();
+        }
+        private void ChangelogUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateChangelog = false;
+            main.config.p3fConfig.updateChangelog = false;
             main.updateConfig();
         }
         private void DeleteChecked(object sender, RoutedEventArgs e)
@@ -219,5 +259,10 @@ namespace AemulusModManager
             UnpackButton.IsHitTestVisible = true;
         }
 
+        // Stops the user from changing the displayed "Notifications" text to the names of one of the combo boxes
+        private void NotifBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            NotifBox.SelectedIndex = 0;
+        }
     }
 }

--- a/Windows/ConfigWindowP3F.xaml.cs
+++ b/Windows/ConfigWindowP3F.xaml.cs
@@ -34,6 +34,7 @@ namespace AemulusModManager
             ConfirmUpdateBox.IsChecked = main.config.p3fConfig.updateConfirm;
             ChangelogBox.IsChecked = main.config.p3fConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p3fConfig.deleteOldVersions;
+            UpdateAllBox.IsChecked = main.config.p3fConfig.updateAll;
             Console.WriteLine("[INFO] Config launched");
         }
 
@@ -99,6 +100,19 @@ namespace AemulusModManager
         {
             main.updateChangelog = false;
             main.config.p3fConfig.updateChangelog = false;
+            main.updateConfig();
+        }
+        private void UpdateAllChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateAll = true;
+            main.config.p3fConfig.updateAll = true;
+            main.updateConfig();
+        }
+
+        private void UpdateAllUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateAll = false;
+            main.config.p3fConfig.updateAll = false;
             main.updateConfig();
         }
         private void DeleteChecked(object sender, RoutedEventArgs e)

--- a/Windows/ConfigWindowP4G.xaml
+++ b/Windows/ConfigWindowP4G.xaml
@@ -62,12 +62,13 @@
                 </CheckBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="4">
-                <CheckBox Name="NotifBox" Foreground ="White" Checked="NotifChecked" Unchecked="NotifUnchecked">
-                    <TextBlock TextAlignment="Center">
-                        Disable<LineBreak/>
-                        Notfication
-                    </TextBlock>
-                </CheckBox>
+                <ComboBox x:Name="NotifBox" Width="120" FontSize="15" Text="Notifications" SelectedIndex="0" SelectionChanged="NotifBox_SelectionChanged">
+                    <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
+                    <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
+                    <CheckBox x:Name="BuildFinishedBox" Content="Build Finished" Checked="BuildFinishedChecked" Unchecked="BuildFinishedUnchecked"/>
+                    <CheckBox x:Name="ConfirmUpdateBox" Content="Confirm Update" Checked="ConfirmUpdateChecked" Unchecked="ConfirmUpdateUnchecked"/>
+                    <CheckBox x:Name="ChangelogBox" Content="Update Changelog" Checked="ChangelogChecked" Unchecked="ChangelogUnchecked"/>
+                </ComboBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="2">
                 <CheckBox Name="DeleteBox" Foreground ="White" Checked="DeleteChecked" Unchecked="DeleteUnchecked">

--- a/Windows/ConfigWindowP4G.xaml
+++ b/Windows/ConfigWindowP4G.xaml
@@ -44,6 +44,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" MinWidth="90" MaxWidth="90" Grid.Column="0">
@@ -75,6 +76,14 @@
                     <TextBlock TextAlignment="Center">
                         Delete Old<LineBreak/>
                         Versions
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="3">
+                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked">
+                    <TextBlock TextAlignment="Center">
+                        Update All<LineBreak/>
+                        On Refresh
                     </TextBlock>
                 </CheckBox>
             </Viewbox>

--- a/Windows/ConfigWindowP4G.xaml.cs
+++ b/Windows/ConfigWindowP4G.xaml.cs
@@ -27,7 +27,10 @@ namespace AemulusModManager
                 ReloadedTextbox.Text = main.launcherPath;
             KeepSND.IsChecked = main.emptySND;
             CpkBox.IsChecked = main.useCpk;
-            NotifBox.IsChecked = main.p4gConfig.disableMessageBox;
+            BuildFinishedBox.IsChecked = main.config.p4gConfig.buildFinished;
+            BuildWarningBox.IsChecked = main.config.p4gConfig.buildWarning;
+            ConfirmUpdateBox.IsChecked = main.config.p4gConfig.updateConfirm;
+            ChangelogBox.IsChecked = main.config.p4gConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p4gConfig.deleteOldVersions;
 
             switch (main.cpkLang)
@@ -81,16 +84,53 @@ namespace AemulusModManager
             main.updateConfig();
         }
 
-        private void NotifChecked(object sender, RoutedEventArgs e)
+        private void BuildWarningChecked(object sender, RoutedEventArgs e)
         {
-            main.messageBox = true;
-            main.config.p4gConfig.disableMessageBox = true;
+            main.buildWarning = true;
+            main.config.p4gConfig.buildWarning = true;
             main.updateConfig();
         }
-        private void NotifUnchecked(object sender, RoutedEventArgs e)
+
+        private void BuildWarningUnchecked(object sender, RoutedEventArgs e)
         {
-            main.messageBox = false;
-            main.config.p4gConfig.disableMessageBox = false;
+            main.buildWarning = false;
+            main.config.p4gConfig.buildWarning = false;
+            main.updateConfig();
+        }
+        private void BuildFinishedChecked(object sender, RoutedEventArgs e)
+        {
+            main.buildFinished = true;
+            main.config.p4gConfig.buildFinished = true;
+            main.updateConfig();
+        }
+        private void BuildFinishedUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.buildFinished = false;
+            main.config.p4gConfig.buildFinished = false;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = true;
+            main.config.p4gConfig.updateConfirm = true;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = false;
+            main.config.p4gConfig.updateConfirm = false;
+            main.updateConfig();
+        }
+        private void ChangelogChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateChangelog = true;
+            main.config.p4gConfig.updateChangelog = true;
+            main.updateConfig();
+        }
+        private void ChangelogUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateChangelog = false;
+            main.config.p4gConfig.updateChangelog = false;
             main.updateConfig();
         }
         private void DeleteChecked(object sender, RoutedEventArgs e)
@@ -259,6 +299,12 @@ namespace AemulusModManager
                 main.cpkLang = selectedLanguage;
                 main.updateConfig();
             }
+        }
+
+        // Stops the user from changing the displayed "Notifications" text to the names of one of the combo boxes
+        private void NotifBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            NotifBox.SelectedIndex = 0;
         }
     }
 }

--- a/Windows/ConfigWindowP4G.xaml.cs
+++ b/Windows/ConfigWindowP4G.xaml.cs
@@ -208,7 +208,7 @@ namespace AemulusModManager
                         button.Foreground = new SolidColorBrush(Colors.Gray);
                         button.IsHitTestVisible = false;
                     }
-                    await main. pacUnpack(directory);
+                    await main.pacUnpack(directory);
                     UnpackButton.IsHitTestVisible = true;
                 }
                 else

--- a/Windows/ConfigWindowP4G.xaml.cs
+++ b/Windows/ConfigWindowP4G.xaml.cs
@@ -32,6 +32,7 @@ namespace AemulusModManager
             ConfirmUpdateBox.IsChecked = main.config.p4gConfig.updateConfirm;
             ChangelogBox.IsChecked = main.config.p4gConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p4gConfig.deleteOldVersions;
+            UpdateAllBox.IsChecked = main.config.p4gConfig.updateAll;
 
             switch (main.cpkLang)
             {
@@ -81,6 +82,20 @@ namespace AemulusModManager
         {
             main.useCpk = false;
             main.config.p4gConfig.useCpk = false;
+            main.updateConfig();
+        }
+
+        private void UpdateAllChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateAll = true;
+            main.config.p4gConfig.updateAll = true;
+            main.updateConfig();
+        }
+
+        private void UpdateAllUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateAll = false;
+            main.config.p4gConfig.updateAll = false;
             main.updateConfig();
         }
 

--- a/Windows/ConfigWindowP5.xaml
+++ b/Windows/ConfigWindowP5.xaml
@@ -36,8 +36,9 @@
         <Button Height="20" Width="60" Content="Browse" Name="EBOOTButton" Click="SetupEBOOTShortcut" Background ="White" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="3" Grid.Column="4"/>
         <Button Height="20" Width="60" Content="Browse" Name="RPCS3Button" Click="SetupRPCS3Shortcut" Background ="White" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="4" Grid.Column="3" Margin="19,11,18,10"/>
 
-        <Grid Grid.Row="7" Grid.Column="2">
+        <Grid Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -57,6 +58,14 @@
                     <TextBlock TextAlignment="Center">
                         Delete Old<LineBreak/>
                         Versions
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="3">
+                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked">
+                    <TextBlock TextAlignment="Center">
+                        Update All<LineBreak/>
+                        On Refresh
                     </TextBlock>
                 </CheckBox>
             </Viewbox>

--- a/Windows/ConfigWindowP5.xaml
+++ b/Windows/ConfigWindowP5.xaml
@@ -44,12 +44,13 @@
             </Grid.ColumnDefinitions>
             <Button Height="30" Width="110" Content="Unpack Base Files" Name="UnpackButton" Grid.Column="0" Click="UnpackPacsClick" Background ="White" VerticalAlignment="Center"/>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="1">
-                <CheckBox Name="NotifBox" Foreground ="White" Checked="NotifChecked" Unchecked="NotifUnchecked">
-                    <TextBlock TextAlignment="Center">
-                        Disable<LineBreak/>
-                        Notification
-                    </TextBlock>
-                </CheckBox>
+                <ComboBox x:Name="NotifBox" Width="120" FontSize="15" Text="Notifications" SelectedIndex="0" SelectionChanged="NotifBox_SelectionChanged">
+                    <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
+                    <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
+                    <CheckBox x:Name="BuildFinishedBox" Content="Build Finished" Checked="BuildFinishedChecked" Unchecked="BuildFinishedUnchecked"/>
+                    <CheckBox x:Name="ConfirmUpdateBox" Content="Confirm Update" Checked="ConfirmUpdateChecked" Unchecked="ConfirmUpdateUnchecked"/>
+                    <CheckBox x:Name="ChangelogBox" Content="Update Changelog" Checked="ChangelogChecked" Unchecked="ChangelogUnchecked"/>
+                </ComboBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="2">
                 <CheckBox Name="DeleteBox" Foreground ="White" Checked="DeleteChecked" Unchecked="DeleteUnchecked">

--- a/Windows/ConfigWindowP5.xaml.cs
+++ b/Windows/ConfigWindowP5.xaml.cs
@@ -131,7 +131,7 @@ namespace AemulusModManager
         // Use 7zip on iso
         private async void UnpackPacsClick(object sender, RoutedEventArgs e)
         {
-            
+
             if (main.gamePath == null || main.gamePath == "")
             {
                 string selectedPath = selectExe("Select P5's EBOOT.BIN to unpack", ".bin");

--- a/Windows/ConfigWindowP5.xaml.cs
+++ b/Windows/ConfigWindowP5.xaml.cs
@@ -25,7 +25,10 @@ namespace AemulusModManager
                 EBOOTTextbox.Text = main.gamePath;
             if (main.launcherPath != null)
                 RPCS3Textbox.Text = main.launcherPath;
-            NotifBox.IsChecked = main.config.p5Config.disableMessageBox;
+            BuildFinishedBox.IsChecked = main.config.p5Config.buildFinished;
+            BuildWarningBox.IsChecked = main.config.p5Config.buildWarning;
+            ConfirmUpdateBox.IsChecked = main.config.p5Config.updateConfirm;
+            ChangelogBox.IsChecked = main.config.p5Config.updateChangelog;
             DeleteBox.IsChecked = main.config.p5Config.deleteOldVersions;
 
             Console.WriteLine("[INFO] Config launched");
@@ -44,16 +47,53 @@ namespace AemulusModManager
                 OutputTextbox.Text = directory;
             }
         }
-        private void NotifChecked(object sender, RoutedEventArgs e)
+        private void BuildWarningChecked(object sender, RoutedEventArgs e)
         {
-            main.messageBox = true;
-            main.config.p5Config.disableMessageBox = true;
+            main.buildWarning = true;
+            main.config.p5Config.buildWarning = true;
             main.updateConfig();
         }
-        private void NotifUnchecked(object sender, RoutedEventArgs e)
+
+        private void BuildWarningUnchecked(object sender, RoutedEventArgs e)
         {
-            main.messageBox = false;
-            main.config.p5Config.disableMessageBox = false;
+            main.buildWarning = false;
+            main.config.p5Config.buildWarning = false;
+            main.updateConfig();
+        }
+        private void BuildFinishedChecked(object sender, RoutedEventArgs e)
+        {
+            main.buildFinished = true;
+            main.config.p5Config.buildFinished = true;
+            main.updateConfig();
+        }
+        private void BuildFinishedUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.buildFinished = false;
+            main.config.p5Config.buildFinished = false;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = true;
+            main.config.p5Config.updateConfirm = true;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = false;
+            main.config.p5Config.updateConfirm = false;
+            main.updateConfig();
+        }
+        private void ChangelogChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateChangelog = true;
+            main.config.p5Config.updateChangelog = true;
+            main.updateConfig();
+        }
+        private void ChangelogUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateChangelog = false;
+            main.config.p5Config.updateChangelog = false;
             main.updateConfig();
         }
         private void DeleteChecked(object sender, RoutedEventArgs e)
@@ -172,5 +212,10 @@ namespace AemulusModManager
             UnpackButton.IsHitTestVisible = true;
         }
 
+        // Stops the user from changing the displayed "Notifications" text to the names of one of the combo boxes
+        private void NotifBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            NotifBox.SelectedIndex = 0;
+        }
     }
 }

--- a/Windows/ConfigWindowP5.xaml.cs
+++ b/Windows/ConfigWindowP5.xaml.cs
@@ -30,7 +30,7 @@ namespace AemulusModManager
             ConfirmUpdateBox.IsChecked = main.config.p5Config.updateConfirm;
             ChangelogBox.IsChecked = main.config.p5Config.updateChangelog;
             DeleteBox.IsChecked = main.config.p5Config.deleteOldVersions;
-
+            UpdateAllBox.IsChecked = main.config.p5Config.updateAll;
             Console.WriteLine("[INFO] Config launched");
         }
         private void modDirectoryClick(object sender, RoutedEventArgs e)
@@ -96,6 +96,19 @@ namespace AemulusModManager
             main.config.p5Config.updateChangelog = false;
             main.updateConfig();
         }
+        private void UpdateAllChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateAll = true;
+            main.config.p5Config.updateAll = true;
+            main.updateConfig();
+        }
+        private void UpdateAllUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateAll = false;
+            main.config.p5Config.updateAll = false;
+            main.updateConfig();
+        }
+
         private void DeleteChecked(object sender, RoutedEventArgs e)
         {
             main.deleteOldVersions = true;

--- a/Windows/CreatePackage.xaml.cs
+++ b/Windows/CreatePackage.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.WindowsAPICodePack.Dialogs;
 using System;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -45,8 +43,8 @@ namespace AemulusModManager
             else
                 CreateButton.IsEnabled = false;
             // Change bool back to false if they deleted both changed entries
-            if (NameBox.Text.Length == 0 
-                && AuthorBox.Text.Length == 0 
+            if (NameBox.Text.Length == 0
+                && AuthorBox.Text.Length == 0
                 && IDBox.Text.Length == 0)
                 edited = false;
             if (!edited)

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:fa5="http://schemas.fontawesome.com/icons/"
         xmlns:local="clr-namespace:AemulusModManager"
         mc:Ignorable="d"
-        Title="Aemulus Package Manager v2.3.3" Height="720" Width="1180" MinHeight="800" MinWidth="1180"
+        Title="Aemulus Package Manager v" Height="720" Width="1180" MinHeight="800" MinWidth="1180"
         Background="#121212" Closing="Window_Closing">
     <Window.Resources>
         <local:UrlConverter x:Key="UrlConverter"/>
@@ -186,6 +186,7 @@
                             <MenuItem Header="Open Package Folder" IsCheckable="False" Click="OpenItem_Click"/>
                             <MenuItem Header="Edit Metadata" IsCheckable="False" Click="EditItem_Click"/>
                             <MenuItem Name="ConvertCPK" Header="Convert CPK Structure" IsCheckable="False" IsEnabled="False" Click="ConvertCPK_Click"/>
+                            <MenuItem Name="UpdateItem" Header="Check For Updates" IsCheckable="False" IsEnabled="False" Click="UpdateItem_Click"/>
                             <MenuItem Header="Delete Package" IsCheckable="False" Click="DeleteItem_Click"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -965,7 +965,7 @@ namespace AemulusModManager
                         }
                     }
             }
-            
+
         }
 
         private void RefreshClick(object sender, RoutedEventArgs e)
@@ -1625,7 +1625,7 @@ namespace AemulusModManager
                     process.Start();
                     process.WaitForExit();
                 }
-                        
+
             });
         }
 
@@ -2088,7 +2088,7 @@ namespace AemulusModManager
 
                 await ExtractPackages(fileList);
 
-                
+
                 ModGrid.IsHitTestVisible = true;
                 foreach (var button in buttons)
                 {
@@ -2122,7 +2122,6 @@ namespace AemulusModManager
                 element.ContextMenu.Visibility = Visibility.Collapsed;
             else
                 element.ContextMenu.Visibility = Visibility.Visible;
-            }
         }
 
         private void UpdateItem_Click(object sender, RoutedEventArgs e)

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -819,6 +819,26 @@ namespace AemulusModManager
                 // Create Package.xml
                 else
                 {
+                    if(game == "Persona 4 Golden")
+                    {
+                        NotificationBox notificationBox = new NotificationBox($"No Package.xml found for {Path.GetFileName(package)}. " +
+                            $"This mod is either old or has been installed incorrectly. Please check that the packages has data_x, data0000x, snd or patches in the root " +
+                            $"as a minimum to function correctly once built.");
+                        notificationBox.Activate();
+                        notificationBox.ShowDialog();
+                        // Open the location of the bad package
+                        try
+                        {
+                            ProcessStartInfo StartInformation = new ProcessStartInfo();
+                            StartInformation.FileName = package;
+                            Process process = Process.Start(StartInformation);
+                            Console.WriteLine($@"[INFO] Opened Packages\{game}\{Path.GetFileName(package)}.");
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine($@"[ERROR] Couldn't open Packages\{game}\{Path.GetFileName(package)} ({ex.Message})");
+                        }
+                    }
                     Console.WriteLine($"[WARNING] No Package.xml found for {Path.GetFileName(package)}, creating one...");
                     // Create metadata
                     Metadata newMetadata = new Metadata();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -42,6 +42,7 @@ namespace AemulusModManager
         public bool buildFinished;
         public bool updateConfirm;
         public bool updateChangelog;
+        public bool updateAll;
         public bool deleteOldVersions;
         public bool fromMain;
         public bool bottomUpPriority;
@@ -302,6 +303,7 @@ namespace AemulusModManager
                             buildFinished = config.p4gConfig.buildFinished;
                             updateConfirm = config.p4gConfig.updateConfirm;
                             updateChangelog = config.p4gConfig.updateChangelog;
+                            updateAll = config.p4gConfig.updateAll;
                             deleteOldVersions = config.p4gConfig.deleteOldVersions;
                             foreach (var button in buttons)
                                 button.Foreground = new SolidColorBrush(Color.FromRgb(0xfe, 0xed, 0x2b));
@@ -316,6 +318,7 @@ namespace AemulusModManager
                             buildFinished = config.p3fConfig.buildFinished;
                             updateConfirm = config.p3fConfig.updateConfirm;
                             updateChangelog = config.p3fConfig.updateChangelog;
+                            updateAll = config.p3fConfig.updateAll;
                             deleteOldVersions = config.p3fConfig.deleteOldVersions;
                             useCpk = false;
                             foreach (var button in buttons)
@@ -330,6 +333,7 @@ namespace AemulusModManager
                             buildFinished = config.p5Config.buildFinished;
                             updateConfirm = config.p5Config.updateConfirm;
                             updateChangelog = config.p5Config.updateChangelog;
+                            updateAll = config.p5Config.updateAll;
                             deleteOldVersions = config.p5Config.deleteOldVersions;
                             useCpk = false;
                             foreach (var button in buttons)
@@ -1071,7 +1075,7 @@ namespace AemulusModManager
                     || (game == "Persona 3 FES" && !Directory.Exists($@"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Original\{game}\DATA")
                     && !Directory.Exists($@"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Original\{game}\BTL"))
                     || (game == "Persona 5" && !Directory.Exists($@"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Original\{game}")))
-            { 
+            {
                 Console.WriteLine("[WARNING] Aemulus can't find your Base files in the Original folder.");
                 Console.WriteLine($"[WARNING] Attempting to unpack base files first.");
 
@@ -1685,6 +1689,7 @@ namespace AemulusModManager
                         buildFinished = config.p3fConfig.buildFinished;
                         updateConfirm = config.p3fConfig.updateConfirm;
                         updateChangelog = config.p3fConfig.updateChangelog;
+                        updateAll = config.p3fConfig.updateAll;
                         deleteOldVersions = config.p3fConfig.deleteOldVersions;
                         useCpk = false;
                         ConvertCPK.Visibility = Visibility.Collapsed;
@@ -1706,6 +1711,7 @@ namespace AemulusModManager
                         buildFinished = config.p4gConfig.buildFinished;
                         updateConfirm = config.p4gConfig.updateConfirm;
                         updateChangelog = config.p4gConfig.updateChangelog;
+                        updateAll = config.p4gConfig.updateAll;
                         deleteOldVersions = config.p4gConfig.deleteOldVersions;
                         ConvertCPK.Visibility = Visibility.Visible;
                         foreach (var button in buttons)
@@ -1723,6 +1729,7 @@ namespace AemulusModManager
                         buildFinished = config.p5Config.buildFinished;
                         updateConfirm = config.p5Config.updateConfirm;
                         updateChangelog = config.p5Config.updateChangelog;
+                        updateAll = config.p5Config.updateAll;
                         deleteOldVersions = config.p5Config.deleteOldVersions;
                         useCpk = false;
                         ConvertCPK.Visibility = Visibility.Collapsed;
@@ -2232,15 +2239,18 @@ namespace AemulusModManager
                 return;
             }
             await UpdateAemulus();
-            updating = true;
-            cancellationToken = new CancellationTokenSource();
-            Console.WriteLine($"[INFO] Checking for updates for all applicable packages");
-            DisplayedMetadata[] updatableRows = DisplayedPackages.Where(RowUpdatable).ToArray();
-            await packageUpdater.CheckForUpdate(updatableRows, game, cancellationToken);
-            updating = false;
-            Refresh();
-            updateConfig();
-            updatePackages();
+            if (updateAll)
+            {
+                updating = true;
+                cancellationToken = new CancellationTokenSource();
+                Console.WriteLine($"[INFO] Checking for updates for all applicable packages");
+                DisplayedMetadata[] updatableRows = DisplayedPackages.Where(RowUpdatable).ToArray();
+                await packageUpdater.CheckForUpdate(updatableRows, game, cancellationToken);
+                updating = false;
+                Refresh();
+                updateConfig();
+                updatePackages();
+            }
         }
 
         private async Task UpdateAemulus()

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -38,7 +38,10 @@ namespace AemulusModManager
         private ObservableCollection<DisplayedMetadata> DisplayedPackages;
         public bool emptySND;
         public bool useCpk;
-        public bool messageBox;
+        public bool buildWarning;
+        public bool buildFinished;
+        public bool updateConfirm;
+        public bool updateChangelog;
         public bool deleteOldVersions;
         public bool fromMain;
         public bool bottomUpPriority;
@@ -202,7 +205,7 @@ namespace AemulusModManager
             PackageList = new ObservableCollection<Package>();
 
             // Initialise package updater
-            packageUpdater = new PackageUpdater();
+            packageUpdater = new PackageUpdater(this);
 
             // Retrieve initial thumbnail from embedded resource
             Assembly asm = Assembly.GetExecutingAssembly();
@@ -297,7 +300,10 @@ namespace AemulusModManager
                             emptySND = config.p4gConfig.emptySND;
                             cpkLang = config.p4gConfig.cpkLang;
                             useCpk = config.p4gConfig.useCpk;
-                            messageBox = config.p4gConfig.disableMessageBox;
+                            buildWarning = config.p4gConfig.buildWarning;
+                            buildFinished = config.p4gConfig.buildFinished;
+                            updateConfirm = config.p4gConfig.updateConfirm;
+                            updateChangelog = config.p4gConfig.updateChangelog;
                             deleteOldVersions = config.p4gConfig.deleteOldVersions;
                             foreach (var button in buttons)
                                 button.Foreground = new SolidColorBrush(Color.FromRgb(0xfe, 0xed, 0x2b));
@@ -308,7 +314,10 @@ namespace AemulusModManager
                             gamePath = config.p3fConfig.isoPath;
                             elfPath = config.p3fConfig.elfPath;
                             launcherPath = config.p3fConfig.launcherPath;
-                            messageBox = config.p3fConfig.disableMessageBox;
+                            buildWarning = config.p3fConfig.buildWarning;
+                            buildFinished = config.p3fConfig.buildFinished;
+                            updateConfirm = config.p3fConfig.updateConfirm;
+                            updateChangelog = config.p3fConfig.updateChangelog;
                             deleteOldVersions = config.p3fConfig.deleteOldVersions;
                             useCpk = false;
                             foreach (var button in buttons)
@@ -319,7 +328,10 @@ namespace AemulusModManager
                             modPath = config.p5Config.modDir;
                             gamePath = config.p5Config.gamePath;
                             launcherPath = config.p5Config.launcherPath;
-                            messageBox = config.p5Config.disableMessageBox;
+                            buildWarning = config.p5Config.buildWarning;
+                            buildFinished = config.p5Config.buildFinished;
+                            updateConfirm = config.p5Config.updateConfirm;
+                            updateChangelog = config.p5Config.updateChangelog;
                             deleteOldVersions = config.p5Config.deleteOldVersions;
                             useCpk = false;
                             foreach (var button in buttons)
@@ -492,7 +504,7 @@ namespace AemulusModManager
                     }
                     ModGrid.IsHitTestVisible = true;
                     GameBox.IsHitTestVisible = true;
-                    if (!fromMain && !messageBox)
+                    if (!fromMain && buildFinished)
                     {
                         NotificationBox notification = new NotificationBox("Finished Unpacking!");
                         notification.ShowDialog();
@@ -1218,7 +1230,7 @@ namespace AemulusModManager
                     }
 
 
-                    if (!messageBox)
+                    if (buildWarning)
                     {
                         bool YesNo = false;
                         Application.Current.Dispatcher.Invoke(() =>
@@ -1241,7 +1253,7 @@ namespace AemulusModManager
                     Application.Current.Dispatcher.Invoke(() =>
                     {
                         Mouse.OverrideCursor = null;
-                        if (!messageBox)
+                        if (buildWarning)
                         {
                             NotificationBox notification = new NotificationBox("Finished emptying output folder!");
                             notification.ShowDialog();
@@ -1259,7 +1271,7 @@ namespace AemulusModManager
                         Directory.CreateDirectory(path);
                     }
 
-                    if (!messageBox && Directory.EnumerateFileSystemEntries(path).Any())
+                    if (buildWarning && Directory.EnumerateFileSystemEntries(path).Any())
                     {
                         bool YesNo = false;
                         Application.Current.Dispatcher.Invoke(() =>
@@ -1307,7 +1319,7 @@ namespace AemulusModManager
                     Application.Current.Dispatcher.Invoke(() =>
                     {
                         Mouse.OverrideCursor = null;
-                        if (!messageBox)
+                        if (buildFinished)
                         {
                             NotificationBox notification = new NotificationBox("Finished Building!");
                             notification.ShowDialog();
@@ -1671,7 +1683,10 @@ namespace AemulusModManager
                         gamePath = config.p3fConfig.isoPath;
                         elfPath = config.p3fConfig.elfPath;
                         launcherPath = config.p3fConfig.launcherPath;
-                        messageBox = config.p3fConfig.disableMessageBox;
+                        buildWarning = config.p3fConfig.buildWarning;
+                        buildFinished = config.p3fConfig.buildFinished;
+                        updateConfirm = config.p3fConfig.updateConfirm;
+                        updateChangelog = config.p3fConfig.updateChangelog;
                         deleteOldVersions = config.p3fConfig.deleteOldVersions;
                         useCpk = false;
                         ConvertCPK.Visibility = Visibility.Collapsed;
@@ -1689,7 +1704,10 @@ namespace AemulusModManager
                         emptySND = config.p4gConfig.emptySND;
                         cpkLang = config.p4gConfig.cpkLang;
                         useCpk = config.p4gConfig.useCpk;
-                        messageBox = config.p4gConfig.disableMessageBox;
+                        buildWarning = config.p4gConfig.buildWarning;
+                        buildFinished = config.p4gConfig.buildFinished;
+                        updateConfirm = config.p4gConfig.updateConfirm;
+                        updateChangelog = config.p4gConfig.updateChangelog;
                         deleteOldVersions = config.p4gConfig.deleteOldVersions;
                         ConvertCPK.Visibility = Visibility.Visible;
                         foreach (var button in buttons)
@@ -1703,7 +1721,10 @@ namespace AemulusModManager
                         modPath = config.p5Config.modDir;
                         gamePath = config.p5Config.gamePath;
                         launcherPath = config.p5Config.launcherPath;
-                        messageBox = config.p5Config.disableMessageBox;
+                        buildWarning = config.p5Config.buildWarning;
+                        buildFinished = config.p5Config.buildFinished;
+                        updateConfirm = config.p5Config.updateConfirm;
+                        updateChangelog = config.p5Config.updateChangelog;
                         deleteOldVersions = config.p5Config.deleteOldVersions;
                         useCpk = false;
                         ConvertCPK.Visibility = Visibility.Collapsed;

--- a/Windows/PackageFolderBox.xaml
+++ b/Windows/PackageFolderBox.xaml
@@ -1,0 +1,26 @@
+﻿<Window x:Class="AemulusModManager.Windows.PackageFolderBox"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AemulusModManager.Windows"
+        mc:Ignorable="d"
+        Title="Aemulus Package Manager"
+        ResizeMode="NoResize"
+        Background="#121212" ShowActivated="True" Closing="Window_Closing" SizeToContent="WidthAndHeight">
+    <Grid>
+        <TextBlock Padding="20" Foreground="White" VerticalAlignment="Top" TextWrapping="WrapWithOverflow" FontSize="15" Text="Multiple Package.xml's found. Please select the correct Aemulus package folder."/>
+        <DataGrid x:Name="FileGrid" HorizontalAlignment="Center" VerticalAlignment="Center" AutoGenerateColumns="False" Margin="25,75,25,40">
+            <DataGrid.Resources>
+                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#9A2000"/>
+                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White"/>
+                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#9A2000" />
+            </DataGrid.Resources>
+            <DataGrid.Columns>
+                <DataGridTextColumn x:Name="FolderColumn" Header="Folder Directory" IsReadOnly="True" Binding="{Binding}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <Button x:Name="SelectButton" Content="Select" HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="75" Margin="41,0,152,10" Click="SelectButton_Click" Background="White" Height="25"/>
+        <Button x:Name="CancelButton" Content="Cancel" HorizontalAlignment="Center" Margin="149,0,44,10" VerticalAlignment="Bottom" Width="75" Height="25" Background="White" Click="CancelButton_Click"/>
+    </Grid>
+</Window>

--- a/Windows/PackageFolderBox.xaml.cs
+++ b/Windows/PackageFolderBox.xaml.cs
@@ -1,44 +1,42 @@
 ﻿using Microsoft.Win32;
 using System;
+using System.Collections.Generic;
 using System.Media;
 using System.Windows;
-using System.Windows.Shell;
+using System.Windows.Data;
 
-namespace AemulusModManager
+namespace AemulusModManager.Windows
 {
     /// <summary>
-    /// Interaction logic for NotificationBox.xaml
+    /// Interaction logic for UpdateFileBox.xaml
     /// </summary>
-    public partial class NotificationBox : Window
+    public partial class PackageFolderBox : Window
     {
-        public bool YesNo = false;
-        public NotificationBox(string message, bool OK = true)
+        public string chosenFolder;
+        public PackageFolderBox(string[] folders, string packageName)
         {
             InitializeComponent();
-            Notification.Text = message;
-            if (OK)
-            {
-                OkButton.Visibility = Visibility.Visible;
-                PlayNotificationSound();
-                taskBarItem.ProgressState = TaskbarItemProgressState.Indeterminate;
-            }
-            else
-            {
-                YesButton.Visibility = Visibility.Visible;
-                NoButton.Visibility = Visibility.Visible;
-            }
-            if (message.Length > 40)
-                Notification.TextAlignment = TextAlignment.Left;
+            FileGrid.ItemsSource = folders;
+            FileGrid.SelectedIndex = 0;
+            Title = $"Aemulus Package Manager - {packageName}";
+            PlayNotificationSound();
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private void SelectButton_Click(object sender, RoutedEventArgs e)
         {
+
+            string selectedItem = (string)FileGrid.SelectedItem;
+            chosenFolder = selectedItem;
             Close();
         }
 
-        private void Yes_Button_Click(object sender, RoutedEventArgs e)
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            YesNo = true;
+
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
             Close();
         }
 

--- a/Windows/PackageFolderBox.xaml.cs
+++ b/Windows/PackageFolderBox.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
 using System.Media;
 using System.Windows;
-using System.Windows.Data;
 
 namespace AemulusModManager.Windows
 {

--- a/Windows/UpdateFileBox.xaml
+++ b/Windows/UpdateFileBox.xaml
@@ -17,8 +17,8 @@
                 <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#9A2000" />
             </DataGrid.Resources>
             <DataGrid.Columns>
-                <DataGridTextColumn x:Name="NameColumn" Header="File Name" IsReadOnly="True"/>
                 <DataGridTextColumn x:Name="DescriptionColumn" Header="File Description" IsReadOnly="True"/>
+                <DataGridTextColumn x:Name="NameColumn" Header="File Name" IsReadOnly="True"/>
                 <DataGridTextColumn x:Name="UploadTimeColumn" Header="Uploaded" IsReadOnly="True"/>
             </DataGrid.Columns>
         </DataGrid>

--- a/Windows/UpdateFileBox.xaml
+++ b/Windows/UpdateFileBox.xaml
@@ -1,0 +1,28 @@
+﻿<Window x:Class="AemulusModManager.Windows.UpdateFileBox"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AemulusModManager.Windows"
+        mc:Ignorable="d"
+        Title="Aemulus Package Manager"
+        ResizeMode="NoResize"
+        Background="#121212" ShowActivated="True" Closing="Window_Closing" SizeToContent="WidthAndHeight">
+    <Grid>
+        <TextBlock Padding="20" Foreground="White" VerticalAlignment="Top" TextWrapping="WrapWithOverflow" FontSize="15" Text="Multiple downloadable files found. Please select the correct one for Aemulus."/>
+        <DataGrid x:Name="FileGrid" HorizontalAlignment="Center" VerticalAlignment="Center" AutoGenerateColumns="False" Margin="25,70,25,40">
+            <DataGrid.Resources>
+                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#9A2000"/>
+                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White"/>
+                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#9A2000" />
+            </DataGrid.Resources>
+            <DataGrid.Columns>
+                <DataGridTextColumn x:Name="NameColumn" Header="File Name" IsReadOnly="True"/>
+                <DataGridTextColumn x:Name="DescriptionColumn" Header="File Description" IsReadOnly="True"/>
+                <DataGridTextColumn x:Name="UploadTimeColumn" Header="Uploaded" IsReadOnly="True"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <Button x:Name="SelectButton" Content="Select" HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="75" Margin="41,0,152,10" Click="SelectButton_Click" Background="White" Height="25"/>
+        <Button x:Name="CancelButton" Content="Cancel" HorizontalAlignment="Center" Margin="149,0,44,10" VerticalAlignment="Bottom" Width="75" Height="25" Background="White" Click="CancelButton_Click"/>
+    </Grid>
+</Window>

--- a/Windows/UpdateFileBox.xaml.cs
+++ b/Windows/UpdateFileBox.xaml.cs
@@ -1,0 +1,104 @@
+﻿using AemulusModManager.Utilities.Windows;
+using Microsoft.Win32;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Media;
+using System.Windows;
+using System.Windows.Data;
+
+namespace AemulusModManager.Windows
+{
+    /// <summary>
+    /// Interaction logic for UpdateFileBox.xaml
+    /// </summary>
+    public partial class UpdateFileBox : Window
+    {
+        public string chosenFileUrl;
+        public string chosenFileName;
+        private readonly string host;
+        // GameBanana Files
+        public UpdateFileBox(Dictionary<String, GameBananaItemFile> files, string packageName)
+        {
+            InitializeComponent();
+            FileGrid.ItemsSource = files;
+            FileGrid.SelectedIndex = 0;
+            NameColumn.Binding = new Binding("Value.FileName");
+            UploadTimeColumn.Binding = new Binding("Value.TimeSinceUpload");
+            DescriptionColumn.Binding = new Binding("Value.Description");
+            Title = $"Aemulus Package Manager - {packageName}";
+            host = "GameBanana";
+            PlayNotificationSound();
+        }
+
+        // GitHub Files
+        public UpdateFileBox(IReadOnlyList<ReleaseAsset> files, string packageName)
+        {
+            InitializeComponent();
+            FileGrid.ItemsSource = files;
+            FileGrid.SelectedIndex = 0;
+            NameColumn.Binding = new Binding("Name");
+            UploadTimeColumn.Binding = new Binding("UpdatedAt")
+            {
+                Converter = new TimeSinceConverter()
+            };
+            DescriptionColumn.Visibility = Visibility.Collapsed;
+            Title = $"Aemulus Package Manager - {packageName}";
+            host = "GitHub";
+            PlayNotificationSound();
+        }
+
+        private void SelectButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (host == "GameBanana")
+            {
+                KeyValuePair<String, GameBananaItemFile> selectedItem = (KeyValuePair<String, GameBananaItemFile>)FileGrid.SelectedItem;
+                chosenFileUrl = selectedItem.Value.DownloadUrl;
+                chosenFileName = selectedItem.Value.FileName;
+            }
+            else if (host == "GitHub")
+            {
+                ReleaseAsset selectedItem = (ReleaseAsset)FileGrid.SelectedItem;
+                chosenFileUrl = selectedItem.BrowserDownloadUrl;
+                chosenFileName = selectedItem.Name;
+            }
+            Close();
+        }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        public void PlayNotificationSound()
+        {
+            bool found = false;
+            try
+            {
+                using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"AppEvents\Schemes\Apps\.Default\Notification.Default\.Current"))
+                {
+                    if (key != null)
+                    {
+                        Object o = key.GetValue(null); // pass null to get (Default)
+                        if (o != null)
+                        {
+                            SoundPlayer theSound = new SoundPlayer((String)o);
+                            theSound.Play();
+                            found = true;
+                        }
+                    }
+                }
+            }
+            catch
+            { }
+            if (!found)
+                SystemSounds.Beep.Play(); // consolation prize
+        }
+    }
+
+}

--- a/Windows/UpdateProgressBox.xaml
+++ b/Windows/UpdateProgressBox.xaml
@@ -1,0 +1,18 @@
+﻿<Window x:Class="AemulusModManager.Windows.UpdateProgressBox"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AemulusModManager.Windows"
+        mc:Ignorable="d"
+        Title="Aemulus Package Manager" Height="175" Width="500"
+        ResizeMode="NoResize"
+        Background="#121212" ShowActivated="True" Closing="Window_Closing">
+    <Grid>
+        <ProgressBar x:Name="progressBar" HorizontalAlignment="Center" Height="24" VerticalAlignment="Center" Width="300" ValueChanged="ProgressBar_ValueChanged"/>
+        <TextBlock x:Name="progressText" HorizontalAlignment="Center" TextWrapping="Wrap" Foreground="White" Text="" VerticalAlignment="Center" Margin="0,90,0,0" FontSize="15"/>
+    </Grid>
+    <Window.TaskbarItemInfo>
+        <TaskbarItemInfo x:Name="taskBarItem" ProgressState="Normal"/>
+    </Window.TaskbarItemInfo>
+</Window>

--- a/Windows/UpdateProgressBox.xaml.cs
+++ b/Windows/UpdateProgressBox.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading;
+using System.Windows;
+
+namespace AemulusModManager.Windows
+{
+    /// <summary>
+    /// Interaction logic for UpdateProgressBox.xaml
+    /// </summary>
+    public partial class UpdateProgressBox : Window
+    {
+        private CancellationTokenSource cancellationTokenSource;
+        public bool finished = false;
+        public UpdateProgressBox(CancellationTokenSource cancellationTokenSource)
+        {
+            InitializeComponent();
+            this.cancellationTokenSource = cancellationTokenSource;
+        }
+
+        private void ProgressBar_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+
+        }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (!finished)
+            {
+                NotificationBox notification = new NotificationBox("Are you sure you want to cancel the download?\nAll progress will be lost.", false);
+                notification.ShowDialog();
+                notification.Activate();
+                if (!notification.YesNo)
+                {
+                    e.Cancel = true;
+                }
+                else
+                {
+                    cancellationTokenSource.Cancel();
+                }
+            }
+        }
+    }
+}

--- a/packages.config
+++ b/packages.config
@@ -2,7 +2,18 @@
 <packages>
   <package id="FontAwesome5" version="2.0.8" targetFramework="net472" />
   <package id="gong-wpf-dragdrop" version="2.3.1" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="Octokit" version="0.49.0" targetFramework="net472" />
+  <package id="Onova" version="2.6.2" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="5.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="5.0.1" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="WindowsAPICodePack-Core" version="1.1.1" targetFramework="net472" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This adds the following:
- Automatically updating packages from GitHub and GameBanana
     - The correct folder from the downloaded zip is automatically extracted to the packages folder based on where Package.xml is
     - The online version is extracted from the title of the latest GameBanana update for the item. This can cause issues if people put numbers other than the version in the title (like TWSTB which is Added Aemulus 1.3.1 support, so it gets the version as 1.3.1) otherwise it always works.
     - Download progress can be seen in a progress bar, downloads can be canceled by closing it or Aemulus overall. This deletes the in-progress files.
     - Packages can be individually updated through a new right click menu option, alternatively whenever refresh is pressed all packages are checked for updates.
     - A changelog is displayed for GB items when they update if enabled in the options
- Automatically updating Aemulus through GameBanana
- Changed notification option from disable notifications to four separate options: Finished Building, Building Warnings, Confirm Update and Update Changelog
- Adds a notification telling you to check the package structure when a package doesn't have package.xml (for p4g only)
- Whenever version number is displayed it is now based off of the AssemblyFileVersion found in AssemblyInfo.cs so you only have to change it in one place when updating.

This was my first time working with wpf so the UI may be a bit off, but I think everything looks alright. 
If there's anything that should be changed or is broken feel free to tell me and I can work it out if you'd like.
I've only tested this with P4G as I haven't done any P5 or P3 modding but it should work for them all the same.