### PR TITLE
Updating Improvements

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -50,4 +50,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("2.4.0.0")]

--- a/Utilities/BinMerging/BinMerger.cs
+++ b/Utilities/BinMerging/BinMerger.cs
@@ -387,7 +387,7 @@ namespace AemulusModManager
                             File.Delete(f);
                     }
                 }
-                if (File.Exists($@"{mod}\field\panel.bin") && Directory.Exists($@"{mod}\field\panel\panel"))
+                if (File.Exists($@"{mod}\field\panel.bin") && !Directory.Exists($@"{mod}\field\panel\panel"))
                     DeleteDirectory($@"{mod}\field\panel\panel");
                 if (Directory.Exists($@"{mod}\battle\result\result") && !Directory.GetFiles($@"{mod}\battle\result\result", "*", SearchOption.AllDirectories).Any())
                     DeleteDirectory($@"{mod}\battle\result\result");

--- a/Utilities/PackageUpdating/DownloadUtils/Zip7Extractor.cs
+++ b/Utilities/PackageUpdating/DownloadUtils/Zip7Extractor.cs
@@ -17,7 +17,7 @@ namespace AemulusModManager.Utilities.PackageUpdating.DownloadUtils
             IProgress<double>? progress = null, CancellationToken cancellationToken = default)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
-            startInfo.CreateNoWindow = true;
+            startInfo.CreateNoWindow = false;
             startInfo.FileName = @$"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Dependencies\7z\7z.exe";
             if (!File.Exists(startInfo.FileName))
             {
@@ -29,12 +29,14 @@ namespace AemulusModManager.Utilities.PackageUpdating.DownloadUtils
             Console.WriteLine($"[INFO] Extracting {sourceFilePath}");
 
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            startInfo.RedirectStandardOutput = true;
             startInfo.UseShellExecute = false;
 
             using (Process process = new Process())
             {
                 process.StartInfo = startInfo;
                 process.Start();
+                Console.WriteLine(process.StandardOutput.ReadToEnd());
                 process.WaitForExit();
             }
             // TODO Check if it actually succeeded (by reading the command output I guess)

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -242,7 +242,7 @@ namespace AemulusModManager
                         if (file.Value.FileMetadata.Values.Count > 2)
                         {
                             string fileTree = file.Value.FileMetadata.Values.ElementAt(2).ToString();
-                            if (fileTree.ToLower().Contains("package.xml") || fileTree.ToLower().Contains("mod.xml"))
+                            if (fileTree.ToLower().Contains("package.xml") || fileTree.ToLower().Contains("mod.xml") || fileTree == "[]")
                             {
                                 aemulusCompatibleFiles.Add(file.Key, file.Value);
                             }

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -120,6 +120,7 @@ namespace AemulusModManager
                     {
                         updateTitle = updates[1].Title;
                         onlineVersionMatch = Regex.Match(updateTitle, @"(?<version>([0-9]+\.?)+)[^a-zA-Z]*");
+                        updateIndex = 1;
                         if (onlineVersionMatch.Success)
                         {
                             onlineVersion = onlineVersionMatch.Groups["version"].Value;
@@ -219,13 +220,16 @@ namespace AemulusModManager
                 {
                     Console.WriteLine($"[INFO] An update is available for {row.name} ({onlineVersion})");
                     // Display the changelog and confirm they want to update
-                    ChangelogBox changelogBox = new ChangelogBox(updates[updateIndex], row.name, $"Would you like to update {row.name} to version {onlineVersion}?", false);
-                    changelogBox.Activate();
-                    changelogBox.ShowDialog();
-                    if (!changelogBox.YesNo)
+                    if (main.updateConfirm)
                     {
-                        Console.WriteLine($"[INFO] Cancelled update for {row.name}");
-                        return;
+                        ChangelogBox changelogBox = new ChangelogBox(updates[updateIndex], row.name, $"Would you like to update {row.name} to version {onlineVersion}?", false);
+                        changelogBox.Activate();
+                        changelogBox.ShowDialog();
+                        if (!changelogBox.YesNo)
+                        {
+                            Console.WriteLine($"[INFO] Cancelled update for {row.name}");
+                            return;
+                        }
                     }
 
                     // Download the update
@@ -456,7 +460,7 @@ namespace AemulusModManager
         private void ExtractFile(string fileName, string game, string oldPath, string packageName, GameBananaItemUpdate update = null)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
-            startInfo.CreateNoWindow = true;
+            startInfo.CreateNoWindow = false;
             startInfo.FileName = @$"{assemblyLocation}\Dependencies\7z\7z.exe";
             if (!File.Exists(startInfo.FileName))
             {
@@ -504,7 +508,7 @@ namespace AemulusModManager
                 Directory.Move(packageRoots[0], $@"{assemblyLocation}\Packages\{game}\{oldPath}");
                 Console.WriteLine($"[INFO] Successfully updated {packageName}");
                 // Display the changelog if it hasn't been displayed already and is wanted
-                if (main.updateChangelog && update != null)
+                if (main.updateChangelog && !main.updateConfirm && update != null)
                 {
                     ChangelogBox changelogBox = new ChangelogBox(update, packageName, $"Successfully updated {packageName}!", true);
                     changelogBox.Activate();
@@ -528,7 +532,7 @@ namespace AemulusModManager
                 Directory.Move(folderBox.chosenFolder, $@"{assemblyLocation}\Packages\{game}\{oldPath}");
                 Console.WriteLine($"[INFO] Successfully updated {packageName}");
                 // Display the changelog if it hasn't been displayed already and is wanted
-                if (main.updateChangelog && update != null)
+                if (main.updateChangelog && !main.updateConfirm && update != null)
                 {
                     ChangelogBox changelogBox = new ChangelogBox(update, packageName, $"Successfully updated {packageName}!", true);
                     changelogBox.Activate();

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -67,7 +67,14 @@ namespace AemulusModManager
                     {
                         for (int i = 0; i < gameBananaRows.Length; i++)
                         {
-                            await GameBananaUpdate(response[i], gameBananaRows[i], game, new Progress<DownloadProgress>(ReportUpdateProgress), CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Token));
+                            try
+                            {
+                                await GameBananaUpdate(response[i], gameBananaRows[i], game, new Progress<DownloadProgress>(ReportUpdateProgress), CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Token));
+                            }
+                            catch(Exception e)
+                            {
+                                Console.WriteLine($"[ERROR] Error whilst updating/checking for updates for {gameBananaRows[i].name}: {e.Message}");
+                            }
                         }
                     }
                 }
@@ -77,9 +84,16 @@ namespace AemulusModManager
                 {
                     foreach (DisplayedMetadata row in gitHubRows)
                     {
-                        Uri uri = CreateUri(row.link);
-                        Release latestRelease = await gitHubClient.Repository.Release.GetLatest(uri.Segments[1].Replace("/", ""), uri.Segments[2].Replace("/", ""));
-                        await GitHubUpdate(latestRelease, row, game, new Progress<DownloadProgress>(ReportUpdateProgress), cancellationToken);
+                        try
+                        {
+                            Uri uri = CreateUri(row.link);
+                            Release latestRelease = await gitHubClient.Repository.Release.GetLatest(uri.Segments[1].Replace("/", ""), uri.Segments[2].Replace("/", ""));
+                            await GitHubUpdate(latestRelease, row, game, new Progress<DownloadProgress>(ReportUpdateProgress), cancellationToken);
+                        }
+                        catch (Exception e)
+                        {
+                            Console.WriteLine($"[ERROR] Error whilst updating/checking for updates for {row.name}: {e.Message}");
+                        }
                     }
                 }
             }

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -237,13 +237,21 @@ namespace AemulusModManager
                 {
                     localVersion = localVersionMatch.Groups["version"].Value;
                 }
+                if(row.skippedVersion != null)
+                {
+                    if(row.skippedVersion == "all" || !UpdateAvailable(onlineVersion, row.skippedVersion))
+                    {
+                        Console.WriteLine($"[INFO] No updates available for {row.name}");
+                        return;
+                    }
+                }
                 if (UpdateAvailable(onlineVersion, localVersion))
                 {
                     Console.WriteLine($"[INFO] An update is available for {row.name} ({onlineVersion})");
                     // Display the changelog and confirm they want to update
                     if (main.updateConfirm)
                     {
-                        ChangelogBox changelogBox = new ChangelogBox(updates[updateIndex], row.name, $"Would you like to update {row.name} to version {onlineVersion}?", false);
+                        ChangelogBox changelogBox = new ChangelogBox(updates[updateIndex], row.name, $"Would you like to update {row.name} to version {onlineVersion}?", row, onlineVersion, $@"{assemblyLocation}\Packages\{game}\{row.path}\Package.xml", false);
                         changelogBox.Activate();
                         changelogBox.ShowDialog();
                         if (!changelogBox.YesNo)
@@ -330,6 +338,14 @@ namespace AemulusModManager
             if (localVersionMatch.Success)
             {
                 localVersion = localVersionMatch.Groups["version"].Value;
+            }
+            if (row.skippedVersion != null)
+            {
+                if (row.skippedVersion == "all" || !UpdateAvailable(onlineVersion, row.skippedVersion))
+                {
+                    Console.WriteLine($"[INFO] No updates available for {row.name}");
+                    return;
+                }
             }
             if (UpdateAvailable(onlineVersion, localVersion))
             {

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -231,7 +231,13 @@ namespace AemulusModManager
                         onlineVersion = onlineVersionMatch.Groups["version"].Value;
                     }
                 }
-                if (UpdateAvailable(onlineVersion, row.version))
+                Match localVersionMatch = Regex.Match(row.version, @"(?<version>([0-9]+\.?)+)[^a-zA-Z]*");
+                string localVersion = null;
+                if (localVersionMatch.Success)
+                {
+                    localVersion = localVersionMatch.Groups["version"].Value;
+                }
+                if (UpdateAvailable(onlineVersion, localVersion))
                 {
                     Console.WriteLine($"[INFO] An update is available for {row.name} ({onlineVersion})");
                     // Display the changelog and confirm they want to update
@@ -313,7 +319,19 @@ namespace AemulusModManager
 
         private async Task GitHubUpdate(Release release, DisplayedMetadata row, string game, Progress<DownloadProgress> progress, CancellationTokenSource cancellationToken)
         {
-            if (UpdateAvailable(release.TagName, row.version))
+            Match onlineVersionMatch = Regex.Match(release.TagName, @"(?<version>([0-9]+\.?)+)[^a-zA-Z]*");
+            string onlineVersion = null;
+            if (onlineVersionMatch.Success)
+            {
+                onlineVersion = onlineVersionMatch.Groups["version"].Value;
+            }
+            Match localVersionMatch = Regex.Match(row.version, @"(?<version>([0-9]+\.?)+)[^a-zA-Z]*");
+            string localVersion = null;
+            if (localVersionMatch.Success)
+            {
+                localVersion = localVersionMatch.Groups["version"].Value;
+            }
+            if (UpdateAvailable(onlineVersion, localVersion))
             {
                 Console.WriteLine($"[INFO] An update is available for {row.name} ({release.TagName})");
                 string downloadUrl, fileName;
@@ -608,7 +626,7 @@ namespace AemulusModManager
 
         private bool UpdateAvailable(string onlineVersion, string localVersion)
         {
-            if (onlineVersion is null)
+            if (onlineVersion is null || localVersion is null)
             {
                 return false;
             }

--- a/Utilities/PackageUpdating/PackageUpdater.cs
+++ b/Utilities/PackageUpdating/PackageUpdater.cs
@@ -58,6 +58,7 @@ namespace AemulusModManager
                     gameBananaRequestUrl += "return_keys=1";
                     // Parse the response
                     string responseString = await client.GetStringAsync(gameBananaRequestUrl);
+                    responseString = responseString.Replace("\"Files().aFiles()\": []", "\"Files().aFiles()\": {}");
                     GameBananaItem[] response = JsonConvert.DeserializeObject<GameBananaItem[]>(responseString);
                     if (response == null)
                     {

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -39,6 +39,7 @@ namespace AemulusModManager
         public bool deleteOldVersions { get; set; }
         public bool buildWarning { get; set; } = true;
         public bool buildFinished { get; set; } = true;
+        public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
         public bool updateAll { get; set; } = true;
     }
@@ -51,6 +52,7 @@ namespace AemulusModManager
         public string launcherPath { get; set; }
         public bool buildWarning { get; set; } = true;
         public bool buildFinished { get; set; } = true;
+        public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
         public bool updateAll { get; set; } = true;
         public bool advancedLaunchOptions { get; set; }
@@ -64,6 +66,7 @@ namespace AemulusModManager
         public string launcherPath { get; set; }
         public bool buildWarning { get; set; } = true;
         public bool buildFinished { get; set; } = true;
+        public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
         public bool updateAll { get; set; } = true;
         public bool deleteOldVersions { get; set; }

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -42,6 +42,7 @@ namespace AemulusModManager
         public bool updateConfirm { get; set; } = true;
         public bool updateChangelog { get; set; } = true;
         public bool updateAll { get; set; } = true;
+        public bool updatesEnabled { get; set; } = true;
     }
 
     public class ConfigP3F
@@ -57,6 +58,7 @@ namespace AemulusModManager
         public bool updateAll { get; set; } = true;
         public bool advancedLaunchOptions { get; set; }
         public bool deleteOldVersions { get; set; }
+        public bool updatesEnabled { get; set; } = true;
     }
 
     public class ConfigP5
@@ -70,6 +72,7 @@ namespace AemulusModManager
         public bool updateChangelog { get; set; } = true;
         public bool updateAll { get; set; } = true;
         public bool deleteOldVersions { get; set; }
+        public bool updatesEnabled { get; set; } = true;
     }
 
     public class Packages

--- a/Utilities/Windows/ConfigObj.cs
+++ b/Utilities/Windows/ConfigObj.cs
@@ -95,6 +95,7 @@ namespace AemulusModManager
         public string version { get; set; }
         public string link { get; set; }
         public string description { get; set; }
+        public string skippedVersion { get; set; }
     }
 
     [Serializable, XmlRoot("Mod")]
@@ -121,6 +122,7 @@ namespace AemulusModManager
         public string description { get; set; }
         public string link { get; set; }
         public string path { get; set; }
+        public string skippedVersion { get; set; }
     }
 
 }

--- a/Windows/ChangelogBox.xaml
+++ b/Windows/ChangelogBox.xaml
@@ -45,8 +45,16 @@
                 </DataGridTextColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <Button x:Name="OkButton" Content="OK" Visibility="Collapsed" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Button_Click" IsDefault="True" Grid.Row="3" Margin="0,0,22,10"/>
-        <Button x:Name="YesButton" Visibility="Collapsed" Content="Yes" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Yes_Button_Click" IsDefault="True" Grid.Row="3" Margin="0,0,130,14"/>
-        <Button x:Name="NoButton" Visibility="Collapsed" Content="No" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Button_Click" Grid.Row="3" Margin="100,0,22,14"/>
+        <Grid Grid.Row="3" Grid.Column="1" Margin="0, 0, 0, 15">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="OkButton" Content="OK" Visibility="Collapsed" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Button_Click" IsDefault="True" Grid.Column="1"/>
+            <Button x:Name="YesButton" Visibility="Collapsed" Content="Yes" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Yes_Button_Click" IsDefault="True" Grid.Column="0"/>
+            <Button x:Name="NoButton" Visibility="Collapsed" Content="No" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Button_Click" Grid.Column="1"/>
+            <Button x:Name="SkipButton" Visibility="Collapsed" Content="Skip Update" Background="White" Height="25" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center" Click="Skip_Button_Click" Grid.Column="2"/>
+        </Grid>
     </Grid>
 </Window>

--- a/Windows/ChangelogBox.xaml.cs
+++ b/Windows/ChangelogBox.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Win32;
 using System;
+using System.IO;
 using System.Media;
 using System.Windows;
+using System.Xml.Serialization;
 
 namespace AemulusModManager.Windows
 {
@@ -11,6 +13,33 @@ namespace AemulusModManager.Windows
     public partial class ChangelogBox : Window
     {
         public bool YesNo = false;
+        private DisplayedMetadata row;
+        private string version;
+        private string path;
+        public ChangelogBox(GameBananaItemUpdate update, string packageName, string text, DisplayedMetadata row, string version, string path, bool OK = true)
+        {
+            this.row = row;
+            this.version = version;
+            this.path = path;
+            InitializeComponent();
+            ChangesGrid.ItemsSource = update.Changes;
+            Title = $"{packageName} Changelog";
+            VersionLabel.Content = update.Title;
+            Text.Text = text;
+            if (OK)
+            {
+                OkButton.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                YesButton.Visibility = Visibility.Visible;
+                NoButton.Visibility = Visibility.Visible;
+                SkipButton.Visibility = Visibility.Visible;
+            }
+            PlayNotificationSound();
+        }
+
+        // An instance where you can't skip the update (only yes or no)
         public ChangelogBox(GameBananaItemUpdate update, string packageName, string text, bool OK = true)
         {
             InitializeComponent();
@@ -32,6 +61,38 @@ namespace AemulusModManager.Windows
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
+            Close();
+        }
+        private void Skip_Button_Click(object sender, RoutedEventArgs e)
+        {
+            // Write that the update should be skipped to the package metadata
+            Metadata m = new Metadata();
+            m.name = row.name;
+            m.author = row.author;
+            m.id = row.id;
+            m.version = row.version;
+            m.link = row.link;
+            m.description = row.description;
+            m.skippedVersion = version;
+            try
+            {
+                using (FileStream streamWriter = File.Create(path))
+                {
+                    try
+                    {
+                        XmlSerializer xsp = new XmlSerializer(typeof(Metadata));
+                        xsp.Serialize(streamWriter, m);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($@"[ERROR] Couldn't serialize {path} ({ex.Message})");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ERROR] Error trying to set skipped version for {row.name}: {ex.Message}");
+            }
             Close();
         }
         private void Yes_Button_Click(object sender, RoutedEventArgs e)

--- a/Windows/ConfigWindowP3F.xaml
+++ b/Windows/ConfigWindowP3F.xaml
@@ -51,6 +51,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Button Height="30" Width="110" Content="Unpack Base Files" Name="UnpackButton" Grid.Column="0" Click="UnpackPacsClick" Background ="White" VerticalAlignment="Center"/>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="1">
@@ -71,7 +72,15 @@
                 </CheckBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="3">
-                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked">
+                <CheckBox Name="UpdateBox" Foreground ="White" Checked="UpdateChecked" Unchecked="UpdateUnchecked">
+                    <TextBlock TextAlignment="Center">
+                        Enable Mod<LineBreak/>
+                        Updates
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="4">
+                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked" IsEnabled="False">
                     <TextBlock TextAlignment="Center">
                         Update All<LineBreak/>
                         On Refresh

--- a/Windows/ConfigWindowP3F.xaml
+++ b/Windows/ConfigWindowP3F.xaml
@@ -58,6 +58,7 @@
                     <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
                     <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
                     <CheckBox x:Name="BuildFinishedBox" Content="Build Finished" Checked="BuildFinishedChecked" Unchecked="BuildFinishedUnchecked"/>
+                    <CheckBox x:Name="ConfirmUpdateBox" Content="Confirm Update" Checked="ConfirmUpdateChecked" Unchecked="ConfirmUpdateUnchecked"/>
                     <CheckBox x:Name="ChangelogBox" Content="Update Changelog" Checked="ChangelogChecked" Unchecked="ChangelogUnchecked"/>
                 </ComboBox>
             </Viewbox>

--- a/Windows/ConfigWindowP3F.xaml.cs
+++ b/Windows/ConfigWindowP3F.xaml.cs
@@ -35,6 +35,7 @@ namespace AemulusModManager
             ChangelogBox.IsChecked = main.config.p3fConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p3fConfig.deleteOldVersions;
             UpdateAllBox.IsChecked = main.config.p3fConfig.updateAll;
+            UpdateBox.IsChecked = main.config.p3fConfig.updatesEnabled;
             Console.WriteLine("[INFO] Config launched");
         }
 
@@ -114,6 +115,22 @@ namespace AemulusModManager
             main.updateAll = false;
             main.config.p3fConfig.updateAll = false;
             main.updateConfig();
+        }
+        private void UpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updatesEnabled = true;
+            main.config.p3fConfig.updatesEnabled = true;
+            main.updateConfig();
+            UpdateAllBox.IsEnabled = true;
+        }
+
+        private void UpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updatesEnabled = false;
+            main.config.p3fConfig.updatesEnabled = false;
+            main.updateConfig();
+            UpdateAllBox.IsChecked = false;
+            UpdateAllBox.IsEnabled = false;
         }
         private void DeleteChecked(object sender, RoutedEventArgs e)
         {

--- a/Windows/ConfigWindowP3F.xaml.cs
+++ b/Windows/ConfigWindowP3F.xaml.cs
@@ -31,6 +31,7 @@ namespace AemulusModManager
             AdvancedLaunchOptions.IsChecked = main.config.p3fConfig.advancedLaunchOptions;
             BuildFinishedBox.IsChecked = main.config.p3fConfig.buildFinished;
             BuildWarningBox.IsChecked = main.config.p3fConfig.buildWarning;
+            ConfirmUpdateBox.IsChecked = main.config.p3fConfig.updateConfirm;
             ChangelogBox.IsChecked = main.config.p3fConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p3fConfig.deleteOldVersions;
             UpdateAllBox.IsChecked = main.config.p3fConfig.updateAll;
@@ -75,6 +76,18 @@ namespace AemulusModManager
         {
             main.buildFinished = false;
             main.config.p3fConfig.buildFinished = false;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = true;
+            main.config.p3fConfig.updateConfirm = true;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = false;
+            main.config.p3fConfig.updateConfirm = false;
             main.updateConfig();
         }
         private void ChangelogChecked(object sender, RoutedEventArgs e)

--- a/Windows/ConfigWindowP4G.xaml
+++ b/Windows/ConfigWindowP4G.xaml
@@ -38,8 +38,9 @@
         <Button Height="20" Width="60" Content="Browse" Name="P4GButton" Click="SetupP4GShortcut" Background ="White" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="3" Grid.Column="4"/>
         <Button Height="20" Width="60" Content="Browse" Name="ReloadedButton" Click="SetupReloadedShortcut" Background ="White" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="4" Grid.Column="3"/>
         
-        <Grid Grid.Row="6" Grid.Column="2">
+        <Grid Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -62,7 +63,7 @@
                     </TextBlock>
                 </CheckBox>
             </Viewbox>
-            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="4">
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="5">
                 <ComboBox x:Name="NotifBox" Width="120" FontSize="15" Text="Notifications" SelectedIndex="0" SelectionChanged="NotifBox_SelectionChanged">
                     <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
                     <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
@@ -80,7 +81,15 @@
                 </CheckBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="3">
-                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked">
+                <CheckBox Name="UpdateBox" Foreground ="White" Checked="UpdateChecked" Unchecked="UpdateUnchecked">
+                    <TextBlock TextAlignment="Center">
+                        Enable Mod<LineBreak/>
+                        Updates
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="4">
+                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked" IsEnabled="False">
                     <TextBlock TextAlignment="Center">
                         Update All<LineBreak/>
                         On Refresh

--- a/Windows/ConfigWindowP4G.xaml
+++ b/Windows/ConfigWindowP4G.xaml
@@ -67,6 +67,7 @@
                     <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
                     <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
                     <CheckBox x:Name="BuildFinishedBox" Content="Build Finished" Checked="BuildFinishedChecked" Unchecked="BuildFinishedUnchecked"/>
+                    <CheckBox x:Name="ConfirmUpdateBox" Content="Confirm Update" Checked="ConfirmUpdateChecked" Unchecked="ConfirmUpdateUnchecked"/>
                     <CheckBox x:Name="ChangelogBox" Content="Update Changelog" Checked="ChangelogChecked" Unchecked="ChangelogUnchecked"/>
                 </ComboBox>
             </Viewbox>

--- a/Windows/ConfigWindowP4G.xaml.cs
+++ b/Windows/ConfigWindowP4G.xaml.cs
@@ -29,6 +29,7 @@ namespace AemulusModManager
             CpkBox.IsChecked = main.useCpk;
             BuildFinishedBox.IsChecked = main.config.p4gConfig.buildFinished;
             BuildWarningBox.IsChecked = main.config.p4gConfig.buildWarning;
+            ConfirmUpdateBox.IsChecked = main.config.p4gConfig.updateConfirm;
             ChangelogBox.IsChecked = main.config.p4gConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p4gConfig.deleteOldVersions;
             UpdateAllBox.IsChecked = main.config.p4gConfig.updateAll;
@@ -121,6 +122,18 @@ namespace AemulusModManager
         {
             main.buildFinished = false;
             main.config.p4gConfig.buildFinished = false;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = true;
+            main.config.p4gConfig.updateConfirm = true;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = false;
+            main.config.p4gConfig.updateConfirm = false;
             main.updateConfig();
         }
         private void ChangelogChecked(object sender, RoutedEventArgs e)

--- a/Windows/ConfigWindowP4G.xaml.cs
+++ b/Windows/ConfigWindowP4G.xaml.cs
@@ -32,6 +32,7 @@ namespace AemulusModManager
             ConfirmUpdateBox.IsChecked = main.config.p4gConfig.updateConfirm;
             ChangelogBox.IsChecked = main.config.p4gConfig.updateChangelog;
             DeleteBox.IsChecked = main.config.p4gConfig.deleteOldVersions;
+            UpdateBox.IsChecked = main.config.p4gConfig.updatesEnabled;
             UpdateAllBox.IsChecked = main.config.p4gConfig.updateAll;
 
             switch (main.cpkLang)
@@ -83,6 +84,23 @@ namespace AemulusModManager
             main.useCpk = false;
             main.config.p4gConfig.useCpk = false;
             main.updateConfig();
+        }
+
+        private void UpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updatesEnabled = true;
+            main.config.p4gConfig.updatesEnabled = true;
+            main.updateConfig();
+            UpdateAllBox.IsEnabled = true;
+        }
+
+        private void UpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updatesEnabled = false;
+            main.config.p4gConfig.updatesEnabled = false;
+            main.updateConfig();
+            UpdateAllBox.IsChecked = false;
+            UpdateAllBox.IsEnabled = false;
         }
 
         private void UpdateAllChecked(object sender, RoutedEventArgs e)

--- a/Windows/ConfigWindowP5.xaml
+++ b/Windows/ConfigWindowP5.xaml
@@ -42,6 +42,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Button Height="30" Width="110" Content="Unpack Base Files" Name="UnpackButton" Grid.Column="0" Click="UnpackPacsClick" Background ="White" VerticalAlignment="Center"/>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="1">
@@ -62,7 +63,15 @@
                 </CheckBox>
             </Viewbox>
             <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="3">
-                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked">
+                <CheckBox Name="UpdateBox" Foreground ="White" Checked="UpdateChecked" Unchecked="UpdateUnchecked">
+                    <TextBlock TextAlignment="Center">
+                        Enable Mod<LineBreak/>
+                        Updates
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" Width="100" Grid.Column="4">
+                <CheckBox Name="UpdateAllBox" Foreground ="White" Checked="UpdateAllChecked" Unchecked="UpdateAllUnchecked" IsEnabled="False">
                     <TextBlock TextAlignment="Center">
                         Update All<LineBreak/>
                         On Refresh

--- a/Windows/ConfigWindowP5.xaml
+++ b/Windows/ConfigWindowP5.xaml
@@ -49,6 +49,7 @@
                     <ComboBoxItem Visibility="Collapsed">Notifications</ComboBoxItem>
                     <CheckBox x:Name="BuildWarningBox" Content="Build Warning" Checked="BuildWarningChecked" Unchecked="BuildWarningUnchecked"/>
                     <CheckBox x:Name="BuildFinishedBox" Content="Build Finished" Checked="BuildFinishedChecked" Unchecked="BuildFinishedUnchecked"/>
+                    <CheckBox x:Name="ConfirmUpdateBox" Content="Confirm Update" Checked="ConfirmUpdateChecked" Unchecked="ConfirmUpdateUnchecked"/>
                     <CheckBox x:Name="ChangelogBox" Content="Update Changelog" Checked="ChangelogChecked" Unchecked="ChangelogUnchecked"/>
                 </ComboBox>
             </Viewbox>

--- a/Windows/ConfigWindowP5.xaml.cs
+++ b/Windows/ConfigWindowP5.xaml.cs
@@ -31,6 +31,7 @@ namespace AemulusModManager
             ChangelogBox.IsChecked = main.config.p5Config.updateChangelog;
             DeleteBox.IsChecked = main.config.p5Config.deleteOldVersions;
             UpdateAllBox.IsChecked = main.config.p5Config.updateAll;
+            UpdateBox.IsChecked = main.config.p5Config.updatesEnabled;
             Console.WriteLine("[INFO] Config launched");
         }
         private void modDirectoryClick(object sender, RoutedEventArgs e)
@@ -108,7 +109,22 @@ namespace AemulusModManager
             main.config.p5Config.updateAll = false;
             main.updateConfig();
         }
+        private void UpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updatesEnabled = true;
+            main.config.p5Config.updatesEnabled = true;
+            main.updateConfig();
+            UpdateAllBox.IsEnabled = true;
+        }
 
+        private void UpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updatesEnabled = false;
+            main.config.p5Config.updatesEnabled = false;
+            main.updateConfig();
+            UpdateAllBox.IsChecked = false;
+            UpdateAllBox.IsEnabled = false;
+        }
         private void DeleteChecked(object sender, RoutedEventArgs e)
         {
             main.deleteOldVersions = true;

--- a/Windows/ConfigWindowP5.xaml.cs
+++ b/Windows/ConfigWindowP5.xaml.cs
@@ -27,6 +27,7 @@ namespace AemulusModManager
                 RPCS3Textbox.Text = main.launcherPath;
             BuildFinishedBox.IsChecked = main.config.p5Config.buildFinished;
             BuildWarningBox.IsChecked = main.config.p5Config.buildWarning;
+            ConfirmUpdateBox.IsChecked = main.config.p5Config.updateConfirm;
             ChangelogBox.IsChecked = main.config.p5Config.updateChangelog;
             DeleteBox.IsChecked = main.config.p5Config.deleteOldVersions;
             UpdateAllBox.IsChecked = main.config.p5Config.updateAll;
@@ -69,6 +70,18 @@ namespace AemulusModManager
         {
             main.buildFinished = false;
             main.config.p5Config.buildFinished = false;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateChecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = true;
+            main.config.p5Config.updateConfirm = true;
+            main.updateConfig();
+        }
+        private void ConfirmUpdateUnchecked(object sender, RoutedEventArgs e)
+        {
+            main.updateConfirm = false;
+            main.config.p5Config.updateConfirm = false;
             main.updateConfig();
         }
         private void ChangelogChecked(object sender, RoutedEventArgs e)

--- a/Windows/CreatePackage.xaml
+++ b/Windows/CreatePackage.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Background="#121212"
         ResizeMode="NoResize"
-        Title="Create New Package" Height="350" Width="500">
+        Title="Create New Package" Height="383" Width="500">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="100"/>
@@ -24,6 +24,7 @@
             <RowDefinition Height="5"/>
             <RowDefinition Height="33"/>
             <RowDefinition Height="33"/>
+            <RowDefinition Height="33"/>
             <RowDefinition Height="5"/>
         </Grid.RowDefinitions>
         <TextBlock Foreground="LightGray" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="15" FontWeight="Bold" Grid.Row="0" Grid.Column="0">Name</TextBlock>
@@ -33,12 +34,26 @@
         <TextBlock Foreground="LightGray" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="15" FontWeight="Bold" Grid.Row="4" Grid.Column="0">Link</TextBlock>
         <TextBlock Foreground="LightGray" VerticalAlignment="Top" Padding="2" HorizontalAlignment="Center" FontSize="15" FontWeight="Bold" Grid.Row="6" Grid.Column="0">Description</TextBlock>
         <TextBlock Foreground="LightGray" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="15" FontWeight="Bold" Grid.Row="8" Grid.Column="0">Preview</TextBlock>
+        <TextBlock Foreground="LightGray" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="15" FontWeight="Bold" Grid.Row="9" Grid.Column="0">Updates</TextBlock>
         <TextBox Name="NameBox" TextChanged="NameBox_TextChanged" Background="White" Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" Width="365"></TextBox>
         <TextBox Name="AuthorBox" TextChanged="AuthorBox_TextChanged" Background="White" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" Width="365"></TextBox>
         <TextBox Name="IDBox" TextChanged="IDBox_TextChanged" IsKeyboardFocusedChanged="IDBox_IsKeyboardFocusedChanged" Background="White" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" Width="365"></TextBox>
         <TextBox Name="VersionBox" Background="White" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" Width="365"></TextBox>
-        <TextBox Name="LinkBox" Background="White" Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" Width="365"></TextBox>
+        <TextBox Name="LinkBox" TextChanged="LinkBox_TextChanged" Background="White" Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" Width="365"></TextBox>
         <TextBox Name="DescBox" AcceptsReturn="True" AcceptsTab="True" Background="White" Grid.Row="6" Grid.Column="1" VerticalScrollBarVisibility="Auto" TextWrapping="WrapWithOverflow" VerticalAlignment="Top" Height="65" HorizontalAlignment="Left" Width="365"></TextBox>
+        <Grid Grid.Row="9" Grid.Column="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="0.5*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Viewbox Stretch="Uniform" VerticalAlignment="Center" MinHeight="35" MaxHeight="35" MinWidth="90" MaxWidth="90" Grid.Column="0">
+                <CheckBox Name="AllowUpdates" Foreground ="White">
+                    <TextBlock TextAlignment="Center">Allow 
+                    <LineBreak/> Updates
+                    </TextBlock>
+                </CheckBox>
+            </Viewbox>
+        </Grid>
         <Grid Grid.Row="8" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -47,7 +62,7 @@
             <TextBox Name="PreviewBox" Background="White" IsReadOnly="True" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left" Width="290"></TextBox>
             <Button Name="PreviewButton" Click="PreviewButton_Click" Background="White" Grid.Row="8" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Width="75">Browse</Button>
         </Grid>
-        <Grid Grid.Row="9" Grid.Column="1">
+        <Grid Grid.Row="10" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
                 <ColumnDefinition/>

--- a/Windows/CreatePackage.xaml.cs
+++ b/Windows/CreatePackage.xaml.cs
@@ -16,6 +16,7 @@ namespace AemulusModManager
         private bool focused = false;
         private bool edited = false;
         private bool editing = false;
+        private string skippedVersion = "";
         public CreatePackage(Metadata m)
         {
             InitializeComponent();
@@ -27,7 +28,30 @@ namespace AemulusModManager
                 VersionBox.Text = m.version;
                 LinkBox.Text = m.link;
                 DescBox.Text = m.description;
+                skippedVersion = m.skippedVersion;
                 editing = true;
+                if (PackageUpdatable())
+                {
+                    AllowUpdates.IsEnabled = true;
+                    if (PackageUpdatable())
+                    {
+                        AllowUpdates.IsEnabled = true;
+                        if (skippedVersion == "all")
+                            AllowUpdates.IsChecked = false;
+                        else
+                            AllowUpdates.IsChecked = true;
+                    }
+                    else
+                    {
+                        AllowUpdates.IsEnabled = false;
+                        AllowUpdates.IsChecked = false;
+                    }
+                }
+                else
+                {
+                    AllowUpdates.IsEnabled = false;
+                    AllowUpdates.IsChecked = false;
+                }
                 if (IDBox.Text != AuthorBox.Text.Replace(" ", "").ToLower() + "."
                         + NameBox.Text.Replace(" ", "").ToLower() && IDBox.Text.Length > 0)
                     edited = true;
@@ -69,6 +93,10 @@ namespace AemulusModManager
                 dirName = $@"Packages\{NameBox.Text}";
             if (!Directory.Exists(dirName) || editing)
             {
+                if ((bool)!AllowUpdates.IsChecked)
+                    metadata.skippedVersion = "all";
+                else
+                    metadata.skippedVersion = null;
                 metadata.name = NameBox.Text;
                 if (AuthorBox.Text != null)
                     metadata.author = AuthorBox.Text;
@@ -147,6 +175,27 @@ namespace AemulusModManager
             }
             // Bring Create Package window back to foreground after closing dialog
             this.Activate();
+        }
+
+        private void LinkBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (PackageUpdatable())
+            {
+                AllowUpdates.IsEnabled = true;
+            }
+            else
+            {
+                AllowUpdates.IsEnabled = false;
+                AllowUpdates.IsChecked = false;
+            }
+        }
+
+        private bool PackageUpdatable()
+        {
+            if (LinkBox.Text == "")
+                return false;
+            string host = UrlConverter.Convert(LinkBox.Text);
+            return (host == "GameBanana" || host == "GitHub") && VersionBox.Text != "";
         }
     }
 }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -40,6 +40,7 @@ namespace AemulusModManager
         public bool useCpk;
         public bool buildWarning;
         public bool buildFinished;
+        public bool updateConfirm;
         public bool updateChangelog;
         public bool updateAll;
         public bool deleteOldVersions;
@@ -175,10 +176,9 @@ namespace AemulusModManager
 
             // Set Aemulus Version
             aemulusVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
-            var version = aemulusVersion.Substring(0, aemulusVersion.LastIndexOf('.'));
-            Title = $"Aemulus Package Manager v{version}";
+            Title = $"Aemulus Package Manager v{aemulusVersion}";
 
-            Console.WriteLine($"[INFO] Launched Aemulus v{version}!");
+            Console.WriteLine($"[INFO] Launched Aemulus v{aemulusVersion}!");
 
             Directory.CreateDirectory($@"Packages");
             Directory.CreateDirectory($@"Original");
@@ -301,6 +301,7 @@ namespace AemulusModManager
                             useCpk = config.p4gConfig.useCpk;
                             buildWarning = config.p4gConfig.buildWarning;
                             buildFinished = config.p4gConfig.buildFinished;
+                            updateConfirm = config.p4gConfig.updateConfirm;
                             updateChangelog = config.p4gConfig.updateChangelog;
                             updateAll = config.p4gConfig.updateAll;
                             deleteOldVersions = config.p4gConfig.deleteOldVersions;
@@ -315,6 +316,7 @@ namespace AemulusModManager
                             launcherPath = config.p3fConfig.launcherPath;
                             buildWarning = config.p3fConfig.buildWarning;
                             buildFinished = config.p3fConfig.buildFinished;
+                            updateConfirm = config.p3fConfig.updateConfirm;
                             updateChangelog = config.p3fConfig.updateChangelog;
                             updateAll = config.p3fConfig.updateAll;
                             deleteOldVersions = config.p3fConfig.deleteOldVersions;
@@ -329,6 +331,7 @@ namespace AemulusModManager
                             launcherPath = config.p5Config.launcherPath;
                             buildWarning = config.p5Config.buildWarning;
                             buildFinished = config.p5Config.buildFinished;
+                            updateConfirm = config.p5Config.updateConfirm;
                             updateChangelog = config.p5Config.updateChangelog;
                             updateAll = config.p5Config.updateAll;
                             deleteOldVersions = config.p5Config.deleteOldVersions;
@@ -816,7 +819,27 @@ namespace AemulusModManager
                 // Create Package.xml
                 else
                 {
-                    
+                    if(game == "Persona 4 Golden")
+                    {
+                        NotificationBox notificationBox = new NotificationBox($"No Package.xml found for {Path.GetFileName(package)}. " +
+                            $"This mod is either old or has been installed incorrectly. Please check that the packages has data_x, data0000x, snd or patches in the root " +
+                            $"as a minimum to function correctly once built.");
+                        notificationBox.Activate();
+                        notificationBox.ShowDialog();
+                        // Open the location of the bad package
+                        try
+                        {
+                            ProcessStartInfo StartInformation = new ProcessStartInfo();
+                            StartInformation.FileName = package;
+                            Process process = Process.Start(StartInformation);
+                            Console.WriteLine($@"[INFO] Opened Packages\{game}\{Path.GetFileName(package)}.");
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine($@"[ERROR] Couldn't open Packages\{game}\{Path.GetFileName(package)} ({ex.Message})");
+                        }
+                    }
+                    Console.WriteLine($"[WARNING] No Package.xml found for {Path.GetFileName(package)}, creating one...");
                     // Create metadata
                     Metadata newMetadata = new Metadata();
                     newMetadata.name = Path.GetFileName(package);
@@ -824,7 +847,7 @@ namespace AemulusModManager
 
 
                     List<string> dirFiles = Directory.GetFiles(package).ToList();
-                    List<string> dirFolders = Directory.GetDirectories(package, "*", SearchOption.TopDirectoryOnly).ToList();
+                    List<string> dirFolders = Directory.GetDirectories(package, "*", System.IO.SearchOption.TopDirectoryOnly).ToList();
                     dirFiles = dirFiles.Concat(dirFolders).ToList();
                     if (File.Exists($@"{package}\Mod.xml") && Directory.Exists($@"{package}\Data"))
                     {
@@ -878,40 +901,6 @@ namespace AemulusModManager
                     }
                     else
                     {
-                        if (game == "Persona 4 Golden" && !(Directory.Exists($@"{package}\data")
-                        || Directory.Exists($@"{package}\data") || Directory.Exists($@"{package}\data_e")
-                        || Directory.Exists($@"{package}\data_c") || Directory.Exists($@"{package}\data_k")
-                        || Directory.Exists($@"{package}\data00000") || Directory.Exists($@"{package}\data00001")
-                        || Directory.Exists($@"{package}\data00002") || Directory.Exists($@"{package}\data00003")
-                        || Directory.Exists($@"{package}\data00004") || Directory.Exists($@"{package}\data00005")
-                        || Directory.Exists($@"{package}\data00006") || Directory.Exists($@"{package}\movie")
-                        || Directory.Exists($@"{package}\movie00000") || Directory.Exists($@"{package}\movie00001")
-                        || Directory.Exists($@"{package}\movie00002") || Directory.Exists($@"{package}\preappfile")
-                        || Directory.Exists($@"{package}\snd") || Directory.Exists($@"{package}\patches")))
-                        {
-                            Application.Current.Dispatcher.Invoke(() =>
-                            {
-                                NotificationBox notificationBox = new NotificationBox($"No Package.xml found for {Path.GetFileName(package)}. " +
-                                $"This mod has been installed incorrectly.\nPlease check that the packages have data_x, data0000x, snd and/or patches folders in the root " +
-                                $"before building.");
-                                notificationBox.ShowDialog();
-                                Activate();
-                            });
-                            // Open the location of the bad package
-                            try
-                            {
-                                ProcessStartInfo StartInformation = new ProcessStartInfo();
-                                StartInformation.FileName = package;
-                                Process process = Process.Start(StartInformation);
-                                Console.WriteLine($@"[INFO] Opened Packages\{game}\{Path.GetFileName(package)}.");
-                            }
-                            catch (Exception ex)
-                            {
-                                Console.WriteLine($@"[ERROR] Couldn't open Packages\{game}\{Path.GetFileName(package)} ({ex.Message})");
-                            }
-                        }
-
-                        Console.WriteLine($"[WARNING] No Package.xml found for {Path.GetFileName(package)}, creating one...");
                         newMetadata.author = "";
                         newMetadata.version = "";
                         newMetadata.link = "";
@@ -1013,12 +1002,12 @@ namespace AemulusModManager
 
         }
 
-        private async void RefreshClick(object sender, RoutedEventArgs e)
+        private void RefreshClick(object sender, RoutedEventArgs e)
         {
             Refresh();
             updateConfig();
             updatePackages();
-            await UpdateAllAsync();
+            UpdateAllAsync();
         }
 
         private void NewClick(object sender, RoutedEventArgs e)
@@ -1718,6 +1707,7 @@ namespace AemulusModManager
                         launcherPath = config.p3fConfig.launcherPath;
                         buildWarning = config.p3fConfig.buildWarning;
                         buildFinished = config.p3fConfig.buildFinished;
+                        updateConfirm = config.p3fConfig.updateConfirm;
                         updateChangelog = config.p3fConfig.updateChangelog;
                         updateAll = config.p3fConfig.updateAll;
                         deleteOldVersions = config.p3fConfig.deleteOldVersions;
@@ -1739,6 +1729,7 @@ namespace AemulusModManager
                         useCpk = config.p4gConfig.useCpk;
                         buildWarning = config.p4gConfig.buildWarning;
                         buildFinished = config.p4gConfig.buildFinished;
+                        updateConfirm = config.p4gConfig.updateConfirm;
                         updateChangelog = config.p4gConfig.updateChangelog;
                         updateAll = config.p4gConfig.updateAll;
                         deleteOldVersions = config.p4gConfig.deleteOldVersions;
@@ -1756,6 +1747,7 @@ namespace AemulusModManager
                         launcherPath = config.p5Config.launcherPath;
                         buildWarning = config.p5Config.buildWarning;
                         buildFinished = config.p5Config.buildFinished;
+                        updateConfirm = config.p5Config.updateConfirm;
                         updateChangelog = config.p5Config.updateChangelog;
                         updateAll = config.p5Config.updateAll;
                         deleteOldVersions = config.p5Config.deleteOldVersions;
@@ -1887,10 +1879,7 @@ namespace AemulusModManager
         private void Setup_Click(object sender, MouseButtonEventArgs e)
         {
             if (File.Exists($@"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Aemulus_Setup.pdf"))
-            {
-                Console.WriteLine($"[INFO] Opening Setup Guide (Note: Guide needs to be updated to include features added in 3.0.0)");
                 Process.Start($@"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Aemulus_Setup.pdf");
-            }
             else
                 Console.WriteLine("[ERROR] Aemulus_Setup.pdf not found.");
         }
@@ -2243,10 +2232,10 @@ namespace AemulusModManager
                 element.ContextMenu.Visibility = Visibility.Visible;
         }
 
-        private async void UpdateItem_Click(object sender, RoutedEventArgs e)
+        private void UpdateItem_Click(object sender, RoutedEventArgs e)
         {
             DisplayedMetadata row = (DisplayedMetadata)ModGrid.SelectedItem;
-            await UpdateItemAsync(row);
+            UpdateItemAsync(row);
         }
 
         private async Task UpdateItemAsync(DisplayedMetadata row)

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace AemulusModManager
         public bool updateConfirm;
         public bool updateChangelog;
         public bool updateAll;
+        public bool updatesEnabled;
         public bool deleteOldVersions;
         public bool fromMain;
         public bool bottomUpPriority;
@@ -304,6 +305,7 @@ namespace AemulusModManager
                             updateConfirm = config.p4gConfig.updateConfirm;
                             updateChangelog = config.p4gConfig.updateChangelog;
                             updateAll = config.p4gConfig.updateAll;
+                            updatesEnabled = config.p4gConfig.updatesEnabled;
                             deleteOldVersions = config.p4gConfig.deleteOldVersions;
                             foreach (var button in buttons)
                                 button.Foreground = new SolidColorBrush(Color.FromRgb(0xfe, 0xed, 0x2b));
@@ -319,6 +321,7 @@ namespace AemulusModManager
                             updateConfirm = config.p3fConfig.updateConfirm;
                             updateChangelog = config.p3fConfig.updateChangelog;
                             updateAll = config.p3fConfig.updateAll;
+                            updatesEnabled = config.p3fConfig.updatesEnabled;
                             deleteOldVersions = config.p3fConfig.deleteOldVersions;
                             useCpk = false;
                             foreach (var button in buttons)
@@ -334,6 +337,7 @@ namespace AemulusModManager
                             updateConfirm = config.p5Config.updateConfirm;
                             updateChangelog = config.p5Config.updateChangelog;
                             updateAll = config.p5Config.updateAll;
+                            updatesEnabled = config.p5Config.updatesEnabled;
                             deleteOldVersions = config.p5Config.deleteOldVersions;
                             useCpk = false;
                             foreach (var button in buttons)
@@ -1426,7 +1430,7 @@ namespace AemulusModManager
 
                 // Enable/disable check for updates
                 UpdateItem.IsEnabled = false;
-                if (RowUpdatable(row) && !updating)
+                if (RowUpdatable(row) && !updating && updatesEnabled)
                     UpdateItem.IsEnabled = true;
                 // TODO Fix menu not updating if you right click a not selected item
 
@@ -1710,6 +1714,7 @@ namespace AemulusModManager
                         updateConfirm = config.p3fConfig.updateConfirm;
                         updateChangelog = config.p3fConfig.updateChangelog;
                         updateAll = config.p3fConfig.updateAll;
+                        updatesEnabled = config.p3fConfig.updatesEnabled;
                         deleteOldVersions = config.p3fConfig.deleteOldVersions;
                         useCpk = false;
                         ConvertCPK.Visibility = Visibility.Collapsed;
@@ -1732,6 +1737,7 @@ namespace AemulusModManager
                         updateConfirm = config.p4gConfig.updateConfirm;
                         updateChangelog = config.p4gConfig.updateChangelog;
                         updateAll = config.p4gConfig.updateAll;
+                        updatesEnabled = config.p4gConfig.updatesEnabled;
                         deleteOldVersions = config.p4gConfig.deleteOldVersions;
                         ConvertCPK.Visibility = Visibility.Visible;
                         foreach (var button in buttons)
@@ -1750,6 +1756,7 @@ namespace AemulusModManager
                         updateConfirm = config.p5Config.updateConfirm;
                         updateChangelog = config.p5Config.updateChangelog;
                         updateAll = config.p5Config.updateAll;
+                        updatesEnabled = config.p5Config.updatesEnabled;
                         deleteOldVersions = config.p5Config.deleteOldVersions;
                         useCpk = false;
                         ConvertCPK.Visibility = Visibility.Collapsed;
@@ -2240,6 +2247,10 @@ namespace AemulusModManager
 
         private async Task UpdateItemAsync(DisplayedMetadata row)
         {
+            if (!updatesEnabled)
+            {
+                return;
+            }
             cancellationToken = new CancellationTokenSource();
             updating = true;
             Console.WriteLine($"[INFO] Checking for updates for {row.name}");
@@ -2252,13 +2263,16 @@ namespace AemulusModManager
 
         private async Task UpdateAllAsync()
         {
-
             if (updating)
             {
                 Console.WriteLine($"[INFO] Packages are already being updated, ignoring request to check for updates");
                 return;
             }
             await UpdateAemulus();
+            if (!updatesEnabled)
+            {
+                return;
+            }
             if (updateAll)
             {
                 updating = true;

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -69,6 +69,7 @@ namespace AemulusModManager
                 dm.version = m.version;
             dm.description = m.description;
             dm.link = m.link;
+            dm.skippedVersion = m.skippedVersion;
             return dm;
         }
 
@@ -417,6 +418,7 @@ namespace AemulusModManager
                                 dm.version = m.version;
                                 dm.link = m.link;
                                 dm.description = m.description;
+                                dm.skippedVersion = m.skippedVersion;
                             }
                         }
                         catch (Exception ex)
@@ -713,6 +715,7 @@ namespace AemulusModManager
                             package.version = metadata.version;
                             package.link = metadata.link;
                             package.description = metadata.description;
+                            package.skippedVersion = metadata.skippedVersion;
                         }
                     }
                     catch (Exception ex)
@@ -1583,6 +1586,7 @@ namespace AemulusModManager
                 m.version = row.version;
                 m.link = row.link;
                 m.description = row.description;
+                m.skippedVersion = row.skippedVersion;
                 CreatePackage createPackage = new CreatePackage(m);
                 createPackage.ShowDialog();
                 if (createPackage.metadata != null)
@@ -1836,6 +1840,7 @@ namespace AemulusModManager
                                     dm.version = m.version;
                                     dm.link = m.link;
                                     dm.description = m.description;
+                                    dm.skippedVersion = m.skippedVersion;
                                 }
                                 catch (Exception ex)
                                 {
@@ -2152,6 +2157,7 @@ namespace AemulusModManager
                                         dm.version = m.version;
                                         dm.link = m.link;
                                         dm.description = m.description;
+                                        dm.skippedVersion = m.skippedVersion;
                                     }
                                 }
                                 catch (Exception ex)
@@ -2304,6 +2310,8 @@ namespace AemulusModManager
         private bool RowUpdatable(DisplayedMetadata row)
         {
             if (row.link == "")
+                return false;
+            if (row.skippedVersion != null && row.skippedVersion == "all")
                 return false;
             string host = UrlConverter.Convert(row.link);
             return (host == "GameBanana" || host == "GitHub") && row.version != "";


### PR DESCRIPTION
This adds:
- A new config option that disables all package updating
- The ability to skip an update with a new button
- The ability for creators to enable or disable updating their package when creating or editing it
     - Internally this uses the skipUpdate property in package.xml, setting it to "all" instead of a version number
- Local version numbers are parsed through the same regex as online ones so packages can have funky version numbers like 3.0H
- When a package is updated the version in package.xml is automatically changed to whatever the online version is, stopping update loops if creators forget to change the version in package.xml
- Fix an issue with GB files that didn't have metadata where this could cause the wrong file to be downloaded. Now they will show in the file choice box like those with a package.xml or mod.xml do.

When I added the skip button I had to adjust the positioning of the yes and no buttons. So, when you get the notification to update Aemulus (doesn't have a skip option) the yes and no buttons are positioned somewhat funny. This will probably need to be altered before pushing the next update (by you if you could try, I'm no good at xaml but I'll try if I need to) 