### PR TITLE
Fix ReplacePackagesXML to work with loadouts

### DIFF
--- a/Utilities/Windows/Loadouts.cs
+++ b/Utilities/Windows/Loadouts.cs
@@ -17,10 +17,10 @@ namespace AemulusModManager.Utilities.Windows
         public Loadouts(string game)
         {
             LoadoutItems = new ObservableCollection<string>();
-            LoadLoadout(game);
+            LoadLoadouts(game);
         }
 
-        public void LoadLoadout(string game)
+        public void LoadLoadouts(string game)
         {
             string configPath = $@"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\Config";
             Console.WriteLine($"[INFO] Loading loadouts for {game}");


### PR DESCRIPTION
Makes it so when downloading a CEP update the current loadout will be switched to the CEP one (currently just gameNamePackages.xml) once it's downloaded.