### PR TITLE
Fix tblpatch sections not working for P5R Switch

### DIFF
--- a/Utilities/TblPatching/TblPatch.cs
+++ b/Utilities/TblPatching/TblPatch.cs
@@ -557,7 +557,7 @@ namespace AemulusModManager
                 return sections;
             }
             bool bigEndian = false;
-            if (game == "Persona 5" || game == "Persona 5 Royal (PS4)")
+            if (game == "Persona 5" || game == "Persona 5 Royal (PS4)" || game == "Persona 5 Royal (Switch)")
                 bigEndian = true;
             using (FileStream
             fileStream = new FileStream(tbl, FileMode.Open))


### PR DESCRIPTION
Tblpatches were essentially unusable for P5R switch because the sections weren't identified causing everything to be in one section. This made UNIT.TBL completely unusable as the length of its one "section" was bigger than an int and for the others it meant you had to always use a section id of 0.
Now it works :)