### PR TITLE
Fix crash extracting p5r switch

### DIFF
--- a/Utilities/PacUnpacker.cs
+++ b/Utilities/PacUnpacker.cs
@@ -681,7 +681,7 @@ namespace AemulusModManager
             {
                 string filePath = string.IsNullOrEmpty(files[x].Directory) ? files[x].FileName : $@"{files[x].Directory}/{files[x].FileName}";
 
-                if (fileList.Contains(filePath) || extractAll)
+                if (extractAll || fileList.Contains(filePath))
                 {
                     extractor.QueueItem(new FileToExtract(Path.Combine(dir, filePath), files[x]));
                     Utilities.ParallelLogger.Log($@"[INFO] Extracting {filePath}");


### PR DESCRIPTION
When unpacking the base files for P5R Switch (and maybe other games, not sure) you could get a null argument exception. 
This is because `fileList.Contains(filePath)` is being run when `filePath` is null, this shouldn't happen because the check for `extractAll` should be first.