### PR TITLE
fix oversight with editing q(2) nametbl pointers

### DIFF
--- a/Utilities/TblPatch.cs
+++ b/Utilities/TblPatch.cs
@@ -395,7 +395,7 @@ namespace AemulusModManager
                             Utilities.ParallelLogger.Log("[ERROR] Improper .tblpatch format.");
                             continue;
                         }
-                        var temp = ReplaceName(sections, file, null);
+                        var temp = ReplaceName(sections, file, null, game);
                         if (temp != null)
                         {
                             sections = temp;
@@ -517,7 +517,7 @@ namespace AemulusModManager
                                 tables.Add(table);
                             }
                             if (patch.tbl == "NAME" || pqNameTbls.Contains(patch.tbl))
-                                tables.Find(x => x.tableName == patch.tbl).nameSections = ReplaceName(tables.Find(x => x.tableName == patch.tbl).nameSections, null, patch);
+                                tables.Find(x => x.tableName == patch.tbl).nameSections = ReplaceName(tables.Find(x => x.tableName == patch.tbl).nameSections, null, patch, game);
                             else
                                 tables.Find(x => x.tableName == patch.tbl).sections = ReplaceSection(tables.Find(x => x.tableName == patch.tbl).sections, patch);
                         }
@@ -720,7 +720,7 @@ namespace AemulusModManager
             return sections;
         }
 
-        private static List<NameSection> ReplaceName(List<NameSection> sections, byte[] patch, TablePatch namePatch)
+        private static List<NameSection> ReplaceName(List<NameSection> sections, byte[] patch, TablePatch namePatch, string game)
         {
             int section = 0;
             int index = 0;
@@ -785,7 +785,7 @@ namespace AemulusModManager
                 int delta = fileContents.Length - sections[section].names[index].Length;
                 sections[section].names[index] = fileContents;
                 sections[section].namesSize += delta;
-                for (int i = index + 1; i < sections[section].pointers.Count; i++)
+                for (int i = (game == "Persona Q" || game == "Persona Q2" ? index : index + 1); i < sections[section].pointers.Count; i++)
                 {
                     sections[section].pointers[i] += (UInt16)delta;
                 }


### PR DESCRIPTION
Unlike P5(R) name tbls, where pointers indicate the start of a name, Q(2) name tbls indicate the _end_ of a name; original Q(2) tblpatching code didn't account this resulting in an off-by-one error where the pointer at `index` needed to be updated but was not.